### PR TITLE
Retrieve document template content for a selected template CEMS-2071

### DIFF
--- a/src/app/dts/dts.component.html
+++ b/src/app/dts/dts.component.html
@@ -11,6 +11,7 @@
   [headerHeight]="50"
   [footerHeight]="50"
   [rowHeight]="50"
+  (activate)='rowClick($event)'
   [messages]="{ emptyMessage: 'No templates found.' }"
   [sorts]="[{prop: 'author', dir: 'asc'}]">
 </ngx-datatable>

--- a/src/app/dts/dts.component.html
+++ b/src/app/dts/dts.component.html
@@ -11,8 +11,8 @@
   [headerHeight]="50"
   [footerHeight]="50"
   [rowHeight]="50"
-  (activate)='rowClick($event)'
+  (activate)="rowClick($event)"
   [messages]="{ emptyMessage: 'No templates found.' }"
-  [sorts]="[{prop: 'author', dir: 'asc'}]">
+  [sorts]="[ {prop: 'author', dir: 'asc'} ]">
 </ngx-datatable>
 

--- a/src/app/dts/dts.component.ts
+++ b/src/app/dts/dts.component.ts
@@ -2,7 +2,6 @@ import {Component} from '@angular/core';
 import {Observable} from 'rxjs';
 import {DtsService} from './dts.service';
 import {Template} from './template.types';
-import {environment} from '../../environments/environment.prod';
 
 @Component({
   selector: 'app-dts',
@@ -26,9 +25,7 @@ export class DtsComponent {
   ];
 
   constructor(private dtsService: DtsService) {
-    console.log(environment.production);
   }
-
 
   /**
    * Populates the data grid with a list of templates.
@@ -45,6 +42,7 @@ export class DtsComponent {
   rowClick(rowEvent): void {
     if (rowEvent.type === 'click') {
       this.dtsService.getTemplateByKey(rowEvent.row.docType, rowEvent.row.templateKey).subscribe(data => {
+        // TODO: CEMS 2078 - Frontend DTS displays selected template in template editor
         console.log(data);
       });
     }

--- a/src/app/dts/dts.component.ts
+++ b/src/app/dts/dts.component.ts
@@ -37,4 +37,16 @@ export class DtsComponent {
   getTemplates(documentType?: string): void {
     this.rows = this.dtsService.getTemplates(documentType);
   }
+
+  /**
+   * Handle row click
+   * @param rowEvent event data for the activated row
+   */
+  rowClick(rowEvent): void {
+    if (rowEvent.type === 'click') {
+      this.dtsService.getTemplateByKey(rowEvent.row.docType, rowEvent.row.templateKey).subscribe(data => {
+        console.log(data);
+      });
+    }
+  }
 }

--- a/src/app/dts/dts.service.spec.ts
+++ b/src/app/dts/dts.service.spec.ts
@@ -56,11 +56,9 @@ describe('DtsService', () => {
 
   it('should return a template given a document type and template key', waitForAsync(inject([DtsService, HttpClient],
     (dtsService: DtsService, http: HttpClient) => {
-      //const template = '<html>\n<head>\n<head>\n<body>\n<p>Hello World</p></body>\n</html>';
       const serviceSpy = spyOn(http, 'get').and.returnValue(of(template));
 
       dtsService.getStatus().subscribe(result => {
-        console.log(result);
         expect(result).toEqual(template);
         expect(serviceSpy).toHaveBeenCalled();
       });

--- a/src/app/dts/dts.service.spec.ts
+++ b/src/app/dts/dts.service.spec.ts
@@ -2,7 +2,7 @@ import {inject, TestBed, waitForAsync} from '@angular/core/testing';
 import {DtsService} from './dts.service';
 import {HttpClient, HttpHandler} from '@angular/common/http';
 import {of} from 'rxjs';
-import {templatesAll, templatesEnrollment} from '../../test/templates';
+import {template, templatesAll, templatesEnrollment} from '../../test/templates';
 
 describe('DtsService', () => {
   let service: DtsService;
@@ -50,6 +50,18 @@ describe('DtsService', () => {
       dtsService.getTemplates('enrollment').subscribe(result => {
         expect(result[0].templateId).toBe('3fa85f64-5717-4562-b3fc-2c963f66afa6');
         expect(result[1].templateId).toBe('1fa85f64-5717-4562-b3fc-2c963f66afa6');
+        expect(serviceSpy).toHaveBeenCalled();
+      });
+    })));
+
+  it('should return a template given a document type and template key', waitForAsync(inject([DtsService, HttpClient],
+    (dtsService: DtsService, http: HttpClient) => {
+      //const template = '<html>\n<head>\n<head>\n<body>\n<p>Hello World</p></body>\n</html>';
+      const serviceSpy = spyOn(http, 'get').and.returnValue(of(template));
+
+      dtsService.getStatus().subscribe(result => {
+        console.log(result);
+        expect(result).toEqual(template);
         expect(serviceSpy).toHaveBeenCalled();
       });
     })));

--- a/src/app/dts/dts.service.spec.ts
+++ b/src/app/dts/dts.service.spec.ts
@@ -2,7 +2,8 @@ import {inject, TestBed, waitForAsync} from '@angular/core/testing';
 import {DtsService} from './dts.service';
 import {HttpClient, HttpHandler} from '@angular/common/http';
 import {of} from 'rxjs';
-import {template, templatesAll, templatesEnrollment} from '../../test/templates';
+import {templatesAll, templatesEnrollment} from '../../test/templates';
+import {template} from '../../test/template';
 
 describe('DtsService', () => {
   let service: DtsService;

--- a/src/app/dts/dts.service.ts
+++ b/src/app/dts/dts.service.ts
@@ -52,7 +52,7 @@ export class DtsService {
    * @param templateKey unique template identifier
    */
   public getTemplateByKey(documentType: string, templateKey: string): Observable<string> {
-    const url = this.url + 'template/' + documentType + '/' + templateKey;
+    const url =  `${this.url}template/${documentType}/${templateKey}`
 
     return this.http.get(url, {responseType: 'text'});
   }

--- a/src/app/dts/dts.service.ts
+++ b/src/app/dts/dts.service.ts
@@ -45,4 +45,15 @@ export class DtsService {
         })
       );
   }
+
+  /**
+   * Gets an HTML template body by document type and template key
+   * @param documentType currently limited to 'enrollment'
+   * @param templateKey unique template identifier
+   */
+  public getTemplateByKey(documentType: string, templateKey: string): Observable<string> {
+    const url = this.url + 'template/' + documentType + '/' + templateKey;
+
+    return this.http.get(url, {responseType: 'text'});
+  }
 }

--- a/src/test/template.ts
+++ b/src/test/template.ts
@@ -1,0 +1,542 @@
+export const template = `
+<html>
+
+<head>
+  <meta charset='utf-8'>
+<meta http-equiv='X-UA-Compatible' content='IE=EmulateIE8' />
+  <style>
+  @page {
+  size: letter portrait;
+}
+
+html,
+  body {
+  font-family: 'Minion Pro', serif;
+  width: 98%;
+  text-align: center;
+  position: relative;
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  border: 10px solid #000;
+  margin: 1cm;
+  padding: 5px;
+  box-sizing: border-box;
+  color: #000000;
+}
+
+html,
+  body {
+  height: 100%;
+}
+
+.page {
+  padding-left: 10px;
+  padding-right: 10px;
+  page-break-after: auto;
+}
+
+.page-divider {
+  page-break-after: always;
+}
+
+span.char-style-override-1 {
+  font-size: 1.3em;
+  font-weight: bold;
+}
+
+span.char-style-override-2 {
+  font-size: 3em;
+  font-weight: bold;
+}
+
+span.char-style-override-3 {
+  font-size: 1.17em;
+}
+
+span.char-style-override-4 {
+  font-size: 1.33em;
+  font-weight: bold;
+}
+
+span.char-style-override-5 {
+  font-size: 0.55em;
+}
+
+span.char-style-override-6 {
+  font-weight: bold;
+}
+
+span.char-style-override-7 {
+  font-size: 1.4em;
+  font-weight: bold;
+}
+
+p {
+  font-family: 'Minion Pro', serif;
+  font-size: 1em;
+  line-height: 1.2;
+  text-align: center;
+}
+
+p.header_images {
+  text-align: left;
+}
+
+img {
+  margin: 5px 5px 5px 5px;
+}
+</style>
+</head>
+
+<body>
+<div id='container' class='page'>
+<p style='text-align:center;'>Enrollment #: <span class='char-style-override-6'>{{ enrollmentId }}</span></p>
+<p><span class='char-style-override-2' style='line-height: 1.2;'>Course Certificate</span></p>
+<p><span class='char-style-override-3'>This is to certify</span></p>
+<p><span class='char-style-override-1'>{{ student.firstName }} {{ student.lastName }}&nbsp;-&nbsp;{{~#each student.licenses as |license|~}}{{license.state}} {{license.type}} {{license.number}}{{#unless @last}}; {{/unless}}{{~/each~}}</span>
+</p>
+<p><span>has successfully completed </span><span class='char-style-override-1'>{{ course.hours }} contact hours</span><span>{{#if (eq course.format 'live')}}Live Continuing Education{{else}}continuing education online training{{/if}} on the topic of:</span>
+</p>
+<p><span class='char-style-override-4'>{{ course.name }}</span><br/>{{#if course.authors}}{{#with course.authors as |authors|}}Course Speakers:{{#each authors~}}{{this}}{{#unless @last}} | {{/unless}}{{~/each}}{{/with}}{{/if}}</p>
+<p><span>Presented by HomeCEUConnection.com, 5048 Tennyson Pkwy, Suite 200 Plano TX 75024</span></p>
+<p><span>Course completed on {{ completionDate }}</span></p>
+</div>
+</body>
+
+</html><html>
+
+<head>
+<meta charset='utf-8'>
+<meta http-equiv='X-UA-Compatible' content='IE=EmulateIE8' />
+  <style>
+  @page {
+  size: letter portrait;
+}
+
+  html,
+    body {
+    font-family: 'Minion Pro', serif;
+    width: 98%;
+    text-align: center;
+    position: relative;
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+  }
+
+  body {
+    border: 10px solid #000;
+    margin: 1cm;
+    padding: 5px;
+    box-sizing: border-box;
+    color: #000000;
+  }
+
+  html,
+    body {
+    height: 100%;
+  }
+
+.page {
+    padding-left: 10px;
+    padding-right: 10px;
+    page-break-after: auto;
+  }
+
+.page-divider {
+    page-break-after: always;
+  }
+
+  span.char-style-override-1 {
+    font-size: 1.3em;
+    font-weight: bold;
+  }
+
+  span.char-style-override-2 {
+    font-size: 3em;
+    font-weight: bold;
+  }
+
+  span.char-style-override-3 {
+    font-size: 1.17em;
+  }
+
+  span.char-style-override-4 {
+    font-size: 1.33em;
+    font-weight: bold;
+  }
+
+  span.char-style-override-5 {
+    font-size: 0.55em;
+  }
+
+  span.char-style-override-6 {
+    font-weight: bold;
+  }
+
+  span.char-style-override-7 {
+    font-size: 1.4em;
+    font-weight: bold;
+  }
+
+  p {
+    font-family: 'Minion Pro', serif;
+    font-size: 1em;
+    line-height: 1.2;
+    text-align: center;
+  }
+
+  p.header_images {
+    text-align: left;
+  }
+
+  img {
+    margin: 5px 5px 5px 5px;
+  }
+  </style>
+  </head>
+
+  <body>
+  <div id='container' class='page'>
+  <p style='text-align:center;'>Enrollment #: <span class='char-style-override-6'>{{ enrollmentId }}</span></p>
+  <p><span class='char-style-override-2' style='line-height: 1.2;'>Course Certificate</span></p>
+  <p><span class='char-style-override-3'>This is to certify</span></p>
+  <p><span class='char-style-override-1'>{{ student.firstName }} {{ student.lastName }}&nbsp;-&nbsp;{{~#each student.licenses as |license|~}}{{license.state}} {{license.type}} {{license.number}}{{#unless @last}}; {{/unless}}{{~/each~}}</span>
+  </p>
+  <p><span>has successfully completed </span><span class='char-style-override-1'>{{ course.hours }} contact hours</span><span>{{#if (eq course.format 'live')}}Live Continuing Education{{else}}continuing education online training{{/if}} on the topic of:</span>
+  </p>
+  <p><span class='char-style-override-4'>{{ course.name }}</span><br/>{{#if course.authors}}{{#with course.authors as |authors|}}Course Speakers:{{#each authors~}}{{this}}{{#unless @last}} | {{/unless}}{{~/each}}{{/with}}{{/if}}</p>
+  <p><span>Presented by HomeCEUConnection.com, 5048 Tennyson Pkwy, Suite 200 Plano TX 75024</span></p>
+  <p><span>Course completed on {{ completionDate }}</span></p>
+  </div>
+  </body>
+
+  </html><html>
+
+  <head>
+  <meta charset='utf-8'>
+  <meta http-equiv='X-UA-Compatible' content='IE=EmulateIE8' />
+    <style>
+    @page {
+    size: letter portrait;
+  }
+
+    html,
+      body {
+      font-family: 'Minion Pro', serif;
+      width: 98%;
+      text-align: center;
+      position: relative;
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      border: 10px solid #000;
+      margin: 1cm;
+      padding: 5px;
+      box-sizing: border-box;
+      color: #000000;
+    }
+
+    html,
+      body {
+      height: 100%;
+    }
+
+  .page {
+      padding-left: 10px;
+      padding-right: 10px;
+      page-break-after: auto;
+    }
+
+  .page-divider {
+      page-break-after: always;
+    }
+
+    span.char-style-override-1 {
+      font-size: 1.3em;
+      font-weight: bold;
+    }
+
+    span.char-style-override-2 {
+      font-size: 3em;
+      font-weight: bold;
+    }
+
+    span.char-style-override-3 {
+      font-size: 1.17em;
+    }
+
+    span.char-style-override-4 {
+      font-size: 1.33em;
+      font-weight: bold;
+    }
+
+    span.char-style-override-5 {
+      font-size: 0.55em;
+    }
+
+    span.char-style-override-6 {
+      font-weight: bold;
+    }
+
+    span.char-style-override-7 {
+      font-size: 1.4em;
+      font-weight: bold;
+    }
+
+    p {
+      font-family: 'Minion Pro', serif;
+      font-size: 1em;
+      line-height: 1.2;
+      text-align: center;
+    }
+
+    p.header_images {
+      text-align: left;
+    }
+
+    img {
+      margin: 5px 5px 5px 5px;
+    }
+    </style>
+    </head>
+
+    <body>
+    <div id='container' class='page'>
+    <p style='text-align:center;'>Enrollment #: <span class='char-style-override-6'>{{ enrollmentId }}</span></p>
+    <p><span class='char-style-override-2' style='line-height: 1.2;'>Course Certificate</span></p>
+    <p><span class='char-style-override-3'>This is to certify</span></p>
+    <p><span class='char-style-override-1'>{{ student.firstName }} {{ student.lastName }}&nbsp;-&nbsp;{{~#each student.licenses as |license|~}}{{license.state}} {{license.type}} {{license.number}}{{#unless @last}}; {{/unless}}{{~/each~}}</span>
+    </p>
+    <p><span>has successfully completed </span><span class='char-style-override-1'>{{ course.hours }} contact hours</span><span>{{#if (eq course.format 'live')}}Live Continuing Education{{else}}continuing education online training{{/if}} on the topic of:</span>
+    </p>
+    <p><span class='char-style-override-4'>{{ course.name }}</span><br/>{{#if course.authors}}{{#with course.authors as |authors|}}Course Speakers:{{#each authors~}}{{this}}{{#unless @last}} | {{/unless}}{{~/each}}{{/with}}{{/if}}</p>
+    <p><span>Presented by HomeCEUConnection.com, 5048 Tennyson Pkwy, Suite 200 Plano TX 75024</span></p>
+    <p><span>Course completed on {{ completionDate }}</span></p>
+    </div>
+    </body>
+
+    </html><html>
+
+    <head>
+    <meta charset='utf-8'>
+    <meta http-equiv='X-UA-Compatible' content='IE=EmulateIE8' />
+      <style>
+      @page {
+      size: letter portrait;
+    }
+
+      html,
+        body {
+        font-family: 'Minion Pro', serif;
+        width: 98%;
+        text-align: center;
+        position: relative;
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        border: 10px solid #000;
+        margin: 1cm;
+        padding: 5px;
+        box-sizing: border-box;
+        color: #000000;
+      }
+
+      html,
+        body {
+        height: 100%;
+      }
+
+    .page {
+        padding-left: 10px;
+        padding-right: 10px;
+        page-break-after: auto;
+      }
+
+    .page-divider {
+        page-break-after: always;
+      }
+
+      span.char-style-override-1 {
+        font-size: 1.3em;
+        font-weight: bold;
+      }
+
+      span.char-style-override-2 {
+        font-size: 3em;
+        font-weight: bold;
+      }
+
+      span.char-style-override-3 {
+        font-size: 1.17em;
+      }
+
+      span.char-style-override-4 {
+        font-size: 1.33em;
+        font-weight: bold;
+      }
+
+      span.char-style-override-5 {
+        font-size: 0.55em;
+      }
+
+      span.char-style-override-6 {
+        font-weight: bold;
+      }
+
+      span.char-style-override-7 {
+        font-size: 1.4em;
+        font-weight: bold;
+      }
+
+      p {
+        font-family: 'Minion Pro', serif;
+        font-size: 1em;
+        line-height: 1.2;
+        text-align: center;
+      }
+
+      p.header_images {
+        text-align: left;
+      }
+
+      img {
+        margin: 5px 5px 5px 5px;
+      }
+      </style>
+      </head>
+
+      <body>
+      <div id='container' class='page'>
+      <p style='text-align:center;'>Enrollment #: <span class='char-style-override-6'>{{ enrollmentId }}</span></p>
+      <p><span class='char-style-override-2' style='line-height: 1.2;'>Course Certificate</span></p>
+      <p><span class='char-style-override-3'>This is to certify</span></p>
+      <p><span class='char-style-override-1'>{{ student.firstName }} {{ student.lastName }}&nbsp;-&nbsp;{{~#each student.licenses as |license|~}}{{license.state}} {{license.type}} {{license.number}}{{#unless @last}}; {{/unless}}{{~/each~}}</span>
+      </p>
+      <p><span>has successfully completed </span><span class='char-style-override-1'>{{ course.hours }} contact hours</span><span>{{#if (eq course.format 'live')}}Live Continuing Education{{else}}continuing education online training{{/if}} on the topic of:</span>
+      </p>
+      <p><span class='char-style-override-4'>{{ course.name }}</span><br/>{{#if course.authors}}{{#with course.authors as |authors|}}Course Speakers:{{#each authors~}}{{this}}{{#unless @last}} | {{/unless}}{{~/each}}{{/with}}{{/if}}</p>
+      <p><span>Presented by HomeCEUConnection.com, 5048 Tennyson Pkwy, Suite 200 Plano TX 75024</span></p>
+      <p><span>Course completed on {{ completionDate }}</span></p>
+      </div>
+      </body>
+
+      </html><html>
+
+      <head>
+      <meta charset='utf-8'>
+      <meta http-equiv='X-UA-Compatible' content='IE=EmulateIE8' />
+        <style>
+        @page {
+        size: letter portrait;
+      }
+
+        html,
+          body {
+          font-family: 'Minion Pro', serif;
+          width: 98%;
+          text-align: center;
+          position: relative;
+          box-sizing: border-box;
+          margin: 0;
+          padding: 0;
+        }
+
+        body {
+          border: 10px solid #000;
+          margin: 1cm;
+          padding: 5px;
+          box-sizing: border-box;
+          color: #000000;
+        }
+
+        html,
+          body {
+          height: 100%;
+        }
+
+      .page {
+          padding-left: 10px;
+          padding-right: 10px;
+          page-break-after: auto;
+        }
+
+      .page-divider {
+          page-break-after: always;
+        }
+
+        span.char-style-override-1 {
+          font-size: 1.3em;
+          font-weight: bold;
+        }
+
+        span.char-style-override-2 {
+          font-size: 3em;
+          font-weight: bold;
+        }
+
+        span.char-style-override-3 {
+          font-size: 1.17em;
+        }
+
+        span.char-style-override-4 {
+          font-size: 1.33em;
+          font-weight: bold;
+        }
+
+        span.char-style-override-5 {
+          font-size: 0.55em;
+        }
+
+        span.char-style-override-6 {
+          font-weight: bold;
+        }
+
+        span.char-style-override-7 {
+          font-size: 1.4em;
+          font-weight: bold;
+        }
+
+        p {
+          font-family: 'Minion Pro', serif;
+          font-size: 1em;
+          line-height: 1.2;
+          text-align: center;
+        }
+
+        p.header_images {
+          text-align: left;
+        }
+
+        img {
+          margin: 5px 5px 5px 5px;
+        }
+        </style>
+        </head>
+
+        <body>
+        <div id='container' class='page'>
+        <p style='text-align:center;'>Enrollment #: <span class='char-style-override-6'>{{ enrollmentId }}</span></p>
+        <p><span class='char-style-override-2' style='line-height: 1.2;'>Course Certificate</span></p>
+        <p><span class='char-style-override-3'>This is to certify</span></p>
+        <p><span class='char-style-override-1'>{{ student.firstName }} {{ student.lastName }}&nbsp;-&nbsp;{{~#each student.licenses as |license|~}}{{license.state}} {{license.type}} {{license.number}}{{#unless @last}}; {{/unless}}{{~/each~}}</span>
+        </p>
+        <p><span>has successfully completed </span><span class='char-style-override-1'>{{ course.hours }} contact hours</span><span>{{#if (eq course.format 'live')}}Live Continuing Education{{else}}continuing education online training{{/if}} on the topic of:</span>
+        </p>
+        <p><span class='char-style-override-4'>{{ course.name }}</span><br/>{{#if course.authors}}{{#with course.authors as |authors|}}Course Speakers:{{#each authors~}}{{this}}{{#unless @last}} | {{/unless}}{{~/each}}{{/with}}{{/if}}</p>
+        <p><span>Presented by HomeCEUConnection.com, 5048 Tennyson Pkwy, Suite 200 Plano TX 75024</span></p>
+        <p><span>Course completed on {{ completionDate }}</span></p>
+        </div>
+        </body>
+
+        </html>`;

--- a/src/test/templates.ts
+++ b/src/test/templates.ts
@@ -1,3 +1,8 @@
+export const template = '<html>\n<head>\n<style>\n.page {\npadding-left: 10px;\npadding-right: 10px;\npage-break-after: auto;\n}\n ' +
+  '</style>\n</head>\n<body>\n<div id="container" class="page">\n<p style="text-align:center;">Enrollment #: <span>{{ enrollmentId }}' +
+  '</span></p>\n<p><span class="char-style-override-2" style="line-height: 1.2;">Course Certificate</span></p>\n</body>\n</html>';
+
+
 export const templatesAll = {
   total: 3,
   items: [

--- a/src/test/templates.ts
+++ b/src/test/templates.ts
@@ -1,8 +1,3 @@
-export const template = '<html>\n<head>\n<style>\n.page {\npadding-left: 10px;\npadding-right: 10px;\npage-break-after: auto;\n}\n ' +
-  '</style>\n</head>\n<body>\n<div id="container" class="page">\n<p style="text-align:center;">Enrollment #: <span>{{ enrollmentId }}' +
-  '</span></p>\n<p><span class="char-style-override-2" style="line-height: 1.2;">Course Certificate</span></p>\n</body>\n</html>';
-
-
 export const templatesAll = {
   total: 3,
   items: [


### PR DESCRIPTION
This update provides the ability to retrieve template content by document type and template key for a selected template.

The frontend dts service was modified with a backend call which conforms to the following specification:
https://homeceu.github.io/dts-docs/#/Templates/getTemplateBodyByKey