### PR TITLE
Template editor with preview CEMS-2078

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3150,6 +3150,15 @@
       "integrity": "sha512-7p4Kn/gffhQaavNfyDFg7LS5S/UT1JAjyGd4UqR2+jzoYF02eDkj0Ec3+48TsIa4zghjLY87nQHIh/ecK9qLdw==",
       "dev": true
     },
+    "ckeditor4-angular": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ckeditor4-angular/-/ckeditor4-angular-2.0.0.tgz",
+      "integrity": "sha512-2dg7faS+KzOhqexOOr5+CEG9v8bhVxCOHnMKLn1GXRVK//Z62ltHx56InJa9k3jQRHeDlIcUhqCP9Yv+sehXAA==",
+      "requires": {
+        "load-script": "^1.0.0",
+        "tslib": "^2.0.0"
+      }
+    },
     "class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -7246,6 +7255,11 @@
       "requires": {
         "immediate": "~3.0.5"
       }
+    },
+    "load-script": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+      "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
     },
     "loader-runner": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@angular/router": "~10.1.5",
     "@swimlane/ngx-datatable": "^18.0.0",
     "@webcomponents/custom-elements": "^1.4.2",
+    "ckeditor4-angular": "^2.0.0",
     "rxjs": "~6.6.0",
     "tslib": "^2.0.0",
     "zone.js": "~0.10.2"

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,6 +3,7 @@ import { Injector, NgModule } from '@angular/core';
 
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { createCustomElement } from '@angular/elements';
+import {CKEditorModule} from 'ckeditor4-angular';
 import { DtsComponent } from './dts/dts.component';
 import {ReactiveFormsModule} from '@angular/forms';
 import {HttpClient, HttpClientModule} from '@angular/common/http';
@@ -13,13 +14,18 @@ import {MatButtonModule} from '@angular/material/button';
 import {MatSelectModule} from '@angular/material/select';
 import {MatInputModule} from '@angular/material/input';
 import {MatIconModule} from '@angular/material/icon';
+import {MatTabsModule} from '@angular/material/tabs';
+
+import {TemplateEditorComponent} from './dts/template-editor/template-editor.component';
 
 @NgModule({
   declarations: [
-    DtsComponent
+    DtsComponent,
+    TemplateEditorComponent
   ],
   imports: [
     BrowserModule,
+    CKEditorModule,
     NoopAnimationsModule,
     ReactiveFormsModule,
     MatAutocompleteModule,
@@ -31,6 +37,7 @@ import {MatIconModule} from '@angular/material/icon';
     MatButtonModule,
     MatInputModule,
     MatSelectModule,
+    MatTabsModule
   ],
   providers: [
     HttpClient

--- a/src/app/dts/dts.component.html
+++ b/src/app/dts/dts.component.html
@@ -1,18 +1,25 @@
-<div>
-  <button mat-raised-button (click)="getTemplates('enrollment')" type="button">
-    Search
-  </button>
-</div>
-<br>
-<ngx-datatable
-  class="material striped"
-  [rows]="rows | async"
-  [columns]="columns"
-  [headerHeight]="50"
-  [footerHeight]="50"
-  [rowHeight]="50"
-  (activate)="rowClick($event)"
-  [messages]="{ emptyMessage: 'No templates found.' }"
-  [sorts]="[ {prop: 'author', dir: 'asc'} ]">
-</ngx-datatable>
-
+<form [formGroup]="dtsForm">
+  <mat-tab-group (selectedTabChange)="tabClick($event)">
+    <mat-tab label="Template">
+      <mat-form-field>
+        <mat-label>Template Key</mat-label>
+        <input matInput type="text" formControlName="templateKey">
+      </mat-form-field>
+      <ngx-datatable
+        class="material striped"
+        [rows]="rows | async"
+        [columns]="columns"
+        [headerHeight]="50"
+        [footerHeight]="50"
+        [rowHeight]="50"
+        (activate)="rowClick($event)"
+        [messages]="{ emptyMessage: 'No templates found.' }"
+        [sorts]="[ {prop: 'author', dir: 'asc'} ]">
+      </ngx-datatable>
+    </mat-tab>
+    <mat-tab label="Edit" [disabled]="selectedTemplate == null">
+      <app-template-editor *ngIf="showEditor" [templateObject]="selectedTemplate">
+      </app-template-editor>
+    </mat-tab>
+  </mat-tab-group>
+</form>

--- a/src/app/dts/dts.component.html
+++ b/src/app/dts/dts.component.html
@@ -1,25 +1,19 @@
-<form [formGroup]="dtsForm">
-  <mat-tab-group (selectedTabChange)="tabClick($event)">
-    <mat-tab label="Template">
-      <mat-form-field>
-        <mat-label>Template Key</mat-label>
-        <input matInput type="text" formControlName="templateKey">
-      </mat-form-field>
-      <ngx-datatable
-        class="material striped"
-        [rows]="rows | async"
-        [columns]="columns"
-        [headerHeight]="50"
-        [footerHeight]="50"
-        [rowHeight]="50"
-        (activate)="rowClick($event)"
-        [messages]="{ emptyMessage: 'No templates found.' }"
-        [sorts]="[ {prop: 'author', dir: 'asc'} ]">
-      </ngx-datatable>
-    </mat-tab>
-    <mat-tab label="Edit" [disabled]="selectedTemplate == null">
-      <app-template-editor *ngIf="showEditor" [templateObject]="selectedTemplate">
-      </app-template-editor>
-    </mat-tab>
-  </mat-tab-group>
-</form>
+<mat-tab-group (selectedTabChange)="tabClick($event)">
+  <mat-tab label="Template">
+    <ngx-datatable
+      class="material striped"
+      [rows]="rows | async"
+      [columns]="columns"
+      [headerHeight]="50"
+      [footerHeight]="50"
+      [rowHeight]="50"
+      (activate)="rowClick($event)"
+      [messages]="{ emptyMessage: 'No templates found.' }"
+      [sorts]="[ {prop: 'author', dir: 'asc'} ]">
+    </ngx-datatable>
+  </mat-tab>
+  <mat-tab label="Edit" [disabled]="selectedTemplate == null">
+    <app-template-editor *ngIf="showEditor" [templateObject]="selectedTemplate">
+    </app-template-editor>
+  </mat-tab>
+</mat-tab-group>

--- a/src/app/dts/dts.component.scss
+++ b/src/app/dts/dts.component.scss
@@ -1,0 +1,11 @@
+.user-list {
+  .nav-link, .nav-link:hover {
+    .is-active-icon {
+      color: green;
+    }
+  }
+
+  .is-active-icon {
+    color: green;
+  }
+}

--- a/src/app/dts/dts.component.spec.ts
+++ b/src/app/dts/dts.component.spec.ts
@@ -1,15 +1,17 @@
-import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {ComponentFixture, inject, TestBed} from '@angular/core/testing';
 import {DtsComponent} from './dts.component';
 import {HttpClient, HttpHandler} from '@angular/common/http';
 import {DtsService} from './dts.service';
 import {of} from 'rxjs';
 import {NgxDatatableModule} from '@swimlane/ngx-datatable';
 import {templatesAll, templatesEnrollment} from '../../test/templates';
+import {FormBuilder} from '@angular/forms';
 
 describe('DtsComponent', () => {
   let component: DtsComponent;
   let fixture: ComponentFixture<DtsComponent>;
   let dtsService: DtsService;
+  let getTemplateSpy = null;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -21,12 +23,14 @@ describe('DtsComponent', () => {
       ],
       providers: [
         HttpClient,
-        HttpHandler
+        HttpHandler,
+        FormBuilder
       ]
     })
     .compileComponents();
 
     dtsService = TestBed.get(DtsService);
+    getTemplateSpy = spyOn(dtsService, 'getTemplates').and.returnValue(of(null));
   });
 
   beforeEach(() => {
@@ -40,10 +44,10 @@ describe('DtsComponent', () => {
   });
 
   it('should display a list of all available templates', done  => {
-    const localTemplateItems = templatesAll.items;
-    spyOn(dtsService, 'getTemplates').and.returnValue(of(localTemplateItems));
+    // reset the spy and expected result
+    dtsService.getTemplates = jasmine.createSpy().and.returnValue(of(templatesAll.items));
 
-    component.getTemplates();
+    fixture.detectChanges();
 
     dtsService.getTemplates().subscribe( result => {
       expect(result.length).toEqual(3);
@@ -52,10 +56,10 @@ describe('DtsComponent', () => {
   });
 
   it('should display a list of templates by document type', done  => {
-    //const localTemplateItems = templates.items.filter(template => template.docType === 'enrollment');
-    spyOn(dtsService, 'getTemplates').and.returnValue(of(templatesEnrollment.items));
+    // reset the spy and expected result
+    dtsService.getTemplates = jasmine.createSpy().and.returnValue(of(templatesEnrollment.items));
 
-    component.getTemplates();
+    fixture.detectChanges();
 
     dtsService.getTemplates().subscribe( result => {
       expect(result.length).toEqual(2);

--- a/src/app/dts/dts.component.spec.ts
+++ b/src/app/dts/dts.component.spec.ts
@@ -5,7 +5,6 @@ import {DtsService} from './dts.service';
 import {of} from 'rxjs';
 import {NgxDatatableModule} from '@swimlane/ngx-datatable';
 import {templatesAll, templatesEnrollment} from '../../test/templates';
-import {FormBuilder, ReactiveFormsModule} from '@angular/forms';
 import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
 
 describe('DtsComponent', () => {
@@ -25,8 +24,7 @@ describe('DtsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
-        NgxDatatableModule,
-        ReactiveFormsModule
+        NgxDatatableModule
       ],
       declarations: [
         DtsComponent
@@ -34,8 +32,7 @@ describe('DtsComponent', () => {
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
       providers: [
         HttpClient,
-        HttpHandler,
-        FormBuilder
+        HttpHandler
       ]
     })
     .compileComponents();

--- a/src/app/dts/dts.component.spec.ts
+++ b/src/app/dts/dts.component.spec.ts
@@ -13,6 +13,15 @@ describe('DtsComponent', () => {
   let fixture: ComponentFixture<DtsComponent>;
   let dtsService: DtsService;
 
+  /**
+   * Create the component which calls the constructor to populate the data grid
+   */
+  function createComponent(): void {
+    fixture = TestBed.createComponent(DtsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
@@ -32,41 +41,31 @@ describe('DtsComponent', () => {
     .compileComponents();
 
     dtsService = TestBed.get(DtsService);
-    spyOn(dtsService, 'getTemplates').and.returnValue(of(null));
-  });
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(DtsComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
+    spyOn(dtsService, 'getTemplates').and.returnValue(of(null));
+    createComponent();
     expect(component).toBeTruthy();
   });
 
-  it('should display a list of all available templates', done  => {
-    // reset the spy and expected result
+  it('should display a list of all available templates', ()  => {
     dtsService.getTemplates = jasmine.createSpy().and.returnValue(of(templatesAll.items));
+    createComponent();
 
-    fixture.detectChanges();
-
-    dtsService.getTemplates().subscribe( result => {
-      expect(result.length).toEqual(3);
-      done();
-    });
+    const gridData = fixture.debugElement.nativeElement.querySelectorAll('.datatable-body');
+    expect(gridData[0].textContent).toEqual('Robert MartinNutritionTemplate3fa85f64-5717-4562-b3fc-2c963f66afa62020-03-05T23:' +
+      '35:12.876ZSteve GilesPhysicalTherapyTemplate1fa85f64-5717-4562-b3fc-2c963f66afa62020-04-05T23:35:12.876ZSue AndersonNursingTem' +
+      'plate2fa85f64-5717-4562-b3fc-2c963f66afa62020-01-05T23:35:12.876Z');
   });
 
-  it('should display a list of templates by document type', done  => {
-    // reset the spy and expected result
+  it('should display a list of templates by document type', ()  => {
     dtsService.getTemplates = jasmine.createSpy().and.returnValue(of(templatesEnrollment.items));
+    createComponent();
 
-    fixture.detectChanges();
-
-    dtsService.getTemplates().subscribe( result => {
-      expect(result.length).toEqual(2);
-      done();
-    });
+    const gridData = fixture.debugElement.nativeElement.querySelectorAll('.datatable-body');
+    expect(gridData[0].textContent).toEqual('Robert MartinNutritionTemplate3fa85f64-5717-4562-b3fc-2c963f66afa62020-03-05T23:' +
+      '35:12.876ZSteve GilesPhysicalTherapyTemplate1fa85f64-5717-4562-b3fc-2c963f66afa62020-04-05T23:35:12.876Z');
   });
 
 });

--- a/src/app/dts/dts.component.spec.ts
+++ b/src/app/dts/dts.component.spec.ts
@@ -1,4 +1,4 @@
-import {ComponentFixture, inject, TestBed} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {DtsComponent} from './dts.component';
 import {HttpClient, HttpHandler} from '@angular/common/http';
 import {DtsService} from './dts.service';
@@ -11,7 +11,6 @@ describe('DtsComponent', () => {
   let component: DtsComponent;
   let fixture: ComponentFixture<DtsComponent>;
   let dtsService: DtsService;
-  let getTemplateSpy = null;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -30,7 +29,7 @@ describe('DtsComponent', () => {
     .compileComponents();
 
     dtsService = TestBed.get(DtsService);
-    getTemplateSpy = spyOn(dtsService, 'getTemplates').and.returnValue(of(null));
+    spyOn(dtsService, 'getTemplates').and.returnValue(of(null));
   });
 
   beforeEach(() => {

--- a/src/app/dts/dts.component.spec.ts
+++ b/src/app/dts/dts.component.spec.ts
@@ -5,7 +5,8 @@ import {DtsService} from './dts.service';
 import {of} from 'rxjs';
 import {NgxDatatableModule} from '@swimlane/ngx-datatable';
 import {templatesAll, templatesEnrollment} from '../../test/templates';
-import {FormBuilder} from '@angular/forms';
+import {FormBuilder, ReactiveFormsModule} from '@angular/forms';
+import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
 
 describe('DtsComponent', () => {
   let component: DtsComponent;
@@ -15,11 +16,13 @@ describe('DtsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
-        NgxDatatableModule
+        NgxDatatableModule,
+        ReactiveFormsModule
       ],
       declarations: [
         DtsComponent
       ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
       providers: [
         HttpClient,
         HttpHandler,

--- a/src/app/dts/dts.component.ts
+++ b/src/app/dts/dts.component.ts
@@ -22,7 +22,7 @@ export class DtsComponent {
   showEditor = false;
 
   /**
-   * Selected template whch is passed to the editor component
+   * Selected template passed to the editor component
    */
   selectedTemplate: Template = null;
 
@@ -70,19 +70,7 @@ export class DtsComponent {
 
       this.dtsForm.controls['templateKey'].setValue(rowEvent.row.templateKey);
 
-      this.selectedTemplate = new class implements Template {
-        author: string;
-        bodyUri: string;
-        createdAt: string;
-        docType: string;
-        templateId: string;
-        templateKey: string;
-      };
-      this.selectedTemplate.docType = rowEvent.row.docType;
-      this.selectedTemplate.templateKey = rowEvent.row.templateKey;
-      this.selectedTemplate.createdAt =  rowEvent.row.createdAt;
-      this.selectedTemplate.templateId =  rowEvent.row.templateId;
-      this.selectedTemplate.author =  rowEvent.row.author;
+      this.selectedTemplate = {... rowEvent.row} as Template;
     }
   }
 

--- a/src/app/dts/dts.component.ts
+++ b/src/app/dts/dts.component.ts
@@ -2,8 +2,6 @@ import {Component} from '@angular/core';
 import {Observable} from 'rxjs';
 import {DtsService} from './dts.service';
 import {Template} from './template.types';
-import {FormBuilder, FormControl, FormGroup} from '@angular/forms';
-import {map} from 'rxjs/operators';
 
 @Component({
   selector: 'app-dts',
@@ -26,8 +24,6 @@ export class DtsComponent {
    */
   selectedTemplate: Template = null;
 
-  dtsForm: FormGroup;
-
   /**
    * Columns in the data grid.
    */
@@ -38,27 +34,8 @@ export class DtsComponent {
     { prop: 'createdAt', name: 'Created'}
   ];
 
-  constructor(private dtsService: DtsService, private formBuilder: FormBuilder) {
-    this.dtsForm = this.formBuilder.group({
-      templateKey: new FormControl()
-    });
-
+  constructor(private dtsService: DtsService) {
     this.rows = this.dtsService.getTemplates('enrollment');
-
-    this.onValueChanges();
-  }
-
-  /**
-   * Filters templates by the user entered template key
-   */
-  onValueChanges(): void {
-    this.dtsForm.valueChanges.subscribe(val => {
-      this.rows = this.dtsService.getTemplates('enrollment')
-        .pipe(
-          map(templates => templates.filter( (template) => {
-            return template.templateKey.toLowerCase().includes(val.templateKey.toLowerCase());
-        })));
-    });
   }
 
   /**
@@ -67,9 +44,6 @@ export class DtsComponent {
    */
   rowClick(rowEvent): void {
     if (rowEvent.type === 'click') {
-
-      this.dtsForm.controls['templateKey'].setValue(rowEvent.row.templateKey);
-
       this.selectedTemplate = {... rowEvent.row} as Template;
     }
   }

--- a/src/app/dts/dts.service.ts
+++ b/src/app/dts/dts.service.ts
@@ -1,9 +1,8 @@
 import {Injectable} from '@angular/core';
-import {HttpClient, HttpHeaders} from '@angular/common/http';
+import {HttpClient} from '@angular/common/http';
 import {Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
 import {environment} from '../../environments/environment';
-import {Template} from './template.types';
 
 @Injectable({
   providedIn: 'root'

--- a/src/app/dts/dts.service.ts
+++ b/src/app/dts/dts.service.ts
@@ -1,8 +1,9 @@
 import {Injectable} from '@angular/core';
-import {HttpClient} from '@angular/common/http';
+import {HttpClient, HttpHeaders} from '@angular/common/http';
 import {Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
 import {environment} from '../../environments/environment';
+import {Template} from './template.types';
 
 @Injectable({
   providedIn: 'root'

--- a/src/app/dts/template-editor/template-editor.component.html
+++ b/src/app/dts/template-editor/template-editor.component.html
@@ -12,15 +12,6 @@
     <input matInput type="text" formControlName="author" [readonly]="true">
   </mat-form-field>
   <ckeditor formControlName="templateData"
-    [config]="{
-      toolbar: [
-        { name: 'basicstyles', items: [ 'Bold', 'Italic' ] },
-        { name: 'clipboard', items: [ 'Cut', 'Copy', 'Paste', 'PasteText', '-', 'Undo', 'Redo' ] },
-        { name: 'document', items: ['Source'] }
-      ],
-      allowedContent: true,
-      fullPage: true,
-      startupMode: 'source',
-      height: '700px'}">
+    [config]="editorConfig">
   </ckeditor>
 </form>

--- a/src/app/dts/template-editor/template-editor.component.html
+++ b/src/app/dts/template-editor/template-editor.component.html
@@ -1,0 +1,26 @@
+<form [formGroup]="templateEditor">
+  <mat-form-field>
+    <mat-label>Template Key</mat-label>
+    <input matInput type="text" formControlName="templateKey" [readonly]="true">
+  </mat-form-field>
+  <mat-form-field class="full-width">
+    <mat-label>Template Id</mat-label>
+    <input matInput type="text" formControlName="templateId" [readonly]="true">
+  </mat-form-field>
+  <mat-form-field>
+    <mat-label>Author</mat-label>
+    <input matInput type="text" formControlName="author" [readonly]="true">
+  </mat-form-field>
+  <ckeditor formControlName="templateData"
+    [config]="{
+      toolbar: [
+        { name: 'basicstyles', items: [ 'Bold', 'Italic' ] },
+        { name: 'clipboard', items: [ 'Cut', 'Copy', 'Paste', 'PasteText', '-', 'Undo', 'Redo' ] },
+        { name: 'document', items: ['Source'] }
+      ],
+      allowedContent: true,
+      fullPage: true,
+      startupMode: 'source',
+      height: '700px'}">
+  </ckeditor>
+</form>

--- a/src/app/dts/template-editor/template-editor.component.scss
+++ b/src/app/dts/template-editor/template-editor.component.scss
@@ -1,0 +1,3 @@
+.full-width {
+  width: 400px;
+}

--- a/src/app/dts/template-editor/template-editor.component.spec.ts
+++ b/src/app/dts/template-editor/template-editor.component.spec.ts
@@ -1,4 +1,4 @@
-import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {ComponentFixture, fakeAsync, flush, TestBed, tick} from '@angular/core/testing';
 import {TemplateEditorComponent} from './template-editor.component';
 import {FormBuilder, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {HttpClient, HttpHandler} from '@angular/common/http';
@@ -64,17 +64,22 @@ describe('TemplateEditorComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should get a template by template key on initialization', done  => {
+  it('should get a template by template key on initialization', fakeAsync(() => {
     spyOn(dtsService, 'getTemplateByKey').and.returnValue(of(template));
 
     component.templateObject.docType = 'dummyDocType';
     component.templateObject.templateKey = 'dummyTemplateKey';
     component.ngOnInit();
+    tick();
 
-    dtsService.getTemplateByKey(component.templateObject.docType, component.templateObject.templateKey).subscribe( result => {
-      expect(result).toEqual(template);
-      done();
-    });
-  });
+    // verify the form control has received the template data
+    expect(component.templateEditor.controls['templateData'].value).toEqual(template);
+
+    // When executing the unit test you can see the template text displayed in the editor so the functionality is working correctly,
+    // however at this point in time the ckeditor control is not yet rendered. Eventually it is rendered as a textarea element with nine
+    // attributes however there is no inner HTML representing the template text so it's currently not possible to verify the editor
+    // displayed with text.
+    // const templateData = fixture.debugElement.nativeElement.querySelectorAll('.cke_source');
+  }));
 
 });

--- a/src/app/dts/template-editor/template-editor.component.spec.ts
+++ b/src/app/dts/template-editor/template-editor.component.spec.ts
@@ -1,0 +1,62 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {TemplateEditorComponent} from './template-editor.component';
+import {FormBuilder} from '@angular/forms';
+import {HttpClient, HttpHandler} from '@angular/common/http';
+import {Template} from '../template.types';
+import {of} from 'rxjs';
+import {DtsService} from '../dts.service';
+import {template} from '../../../test/template';
+
+describe('TemplateEditorComponent', () => {
+  let component: TemplateEditorComponent;
+  let fixture: ComponentFixture<TemplateEditorComponent>;
+  let dtsService: DtsService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ TemplateEditorComponent ],
+      providers: [
+        HttpClient,
+        HttpHandler,
+        FormBuilder
+      ]
+    })
+    .compileComponents();
+
+    dtsService = TestBed.get(DtsService);
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TemplateEditorComponent);
+    component = fixture.componentInstance;
+
+    component.templateObject = new class implements Template {
+      author: '';
+      bodyUri: '';
+      createdAt: '';
+      docType: '';
+      templateId: '';
+      templateKey: '';
+    };
+
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should get a template by template key on initialization', done  => {
+    spyOn(dtsService, 'getTemplateByKey').and.returnValue(of(template));
+
+    component.templateObject.docType = 'dummyDocType';
+    component.templateObject.templateKey = 'dummyTemplateKey';
+    component.ngOnInit();
+
+    dtsService.getTemplateByKey(component.templateObject.docType, component.templateObject.templateKey).subscribe( result => {
+      expect(result).toEqual(template);
+      done();
+    });
+  });
+
+});

--- a/src/app/dts/template-editor/template-editor.component.spec.ts
+++ b/src/app/dts/template-editor/template-editor.component.spec.ts
@@ -30,14 +30,7 @@ describe('TemplateEditorComponent', () => {
     fixture = TestBed.createComponent(TemplateEditorComponent);
     component = fixture.componentInstance;
 
-    component.templateObject = new class implements Template {
-      author: '';
-      bodyUri: '';
-      createdAt: '';
-      docType: '';
-      templateId: '';
-      templateKey: '';
-    };
+    component.templateObject = {} as Template;
 
     fixture.detectChanges();
   });

--- a/src/app/dts/template-editor/template-editor.component.spec.ts
+++ b/src/app/dts/template-editor/template-editor.component.spec.ts
@@ -1,4 +1,4 @@
-import {ComponentFixture, fakeAsync, flush, TestBed, tick} from '@angular/core/testing';
+import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {TemplateEditorComponent} from './template-editor.component';
 import {FormBuilder, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {HttpClient, HttpHandler} from '@angular/common/http';

--- a/src/app/dts/template-editor/template-editor.component.spec.ts
+++ b/src/app/dts/template-editor/template-editor.component.spec.ts
@@ -1,11 +1,13 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TemplateEditorComponent} from './template-editor.component';
-import {FormBuilder} from '@angular/forms';
+import {FormBuilder, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {HttpClient, HttpHandler} from '@angular/common/http';
 import {Template} from '../template.types';
 import {of} from 'rxjs';
 import {DtsService} from '../dts.service';
 import {template} from '../../../test/template';
+import {CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA} from '@angular/core';
+import {CKEditorModule} from 'ckeditor4-angular';
 
 describe('TemplateEditorComponent', () => {
   let component: TemplateEditorComponent;
@@ -14,7 +16,18 @@ describe('TemplateEditorComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ TemplateEditorComponent ],
+      imports: [
+        ReactiveFormsModule,
+        FormsModule,
+        CKEditorModule
+      ],
+      declarations: [
+        TemplateEditorComponent
+      ],
+      schemas: [
+        NO_ERRORS_SCHEMA,
+        CUSTOM_ELEMENTS_SCHEMA
+      ],
       providers: [
         HttpClient,
         HttpHandler,
@@ -29,6 +42,18 @@ describe('TemplateEditorComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(TemplateEditorComponent);
     component = fixture.componentInstance;
+
+    component.editorConfig = {
+      toolbar: [
+        { name: 'basicstyles', items: [ 'Bold', 'Italic' ] },
+        { name: 'clipboard', items: [ 'Cut', 'Copy', 'Paste', 'PasteText', '-', 'Undo', 'Redo' ] },
+        { name: 'document', items: ['Source'] }
+      ],
+      allowedContent: true,
+      fullPage: true,
+      startupMode: 'source',
+      height: '700px'
+    };
 
     component.templateObject = {} as Template;
 

--- a/src/app/dts/template-editor/template-editor.component.ts
+++ b/src/app/dts/template-editor/template-editor.component.ts
@@ -1,0 +1,43 @@
+import {Component, Input, OnInit} from '@angular/core';
+import {FormBuilder, FormControl, FormGroup} from '@angular/forms';
+import {DtsService} from '../dts.service';
+import {Template} from '../template.types';
+
+@Component({
+  selector: 'app-template-editor',
+  templateUrl: './template-editor.component.html',
+  styleUrls: ['./template-editor.component.scss']
+})
+export class TemplateEditorComponent implements OnInit {
+
+  /**
+   * Template to edit
+   */
+  @Input()
+  templateObject: Template;
+
+  templateEditor: FormGroup;
+
+  constructor(private dtsService: DtsService, private formBuilder: FormBuilder) {
+    this.templateEditor = this.formBuilder.group({
+      templateData: new FormControl(),
+      templateKey: new FormControl(),
+      templateId: new FormControl(),
+      author: new FormControl()
+    });
+  }
+
+  /**
+   * Retrieves template and loads template data into the editor
+   */
+  ngOnInit(): void {
+    if (this.templateObject.docType && this.templateObject.templateKey) {
+      this.dtsService.getTemplateByKey(this.templateObject.docType, this.templateObject.templateKey).subscribe(data => {
+        this.templateEditor.controls['templateData'].setValue(data);
+        this.templateEditor.controls['templateKey'].setValue(this.templateObject.templateKey);
+        this.templateEditor.controls['templateId'].setValue(this.templateObject.templateId);
+        this.templateEditor.controls['author'].setValue(this.templateObject.author);
+      });
+    }
+  }
+}

--- a/src/app/dts/template-editor/template-editor.component.ts
+++ b/src/app/dts/template-editor/template-editor.component.ts
@@ -16,6 +16,21 @@ export class TemplateEditorComponent implements OnInit {
   @Input()
   templateObject: Template;
 
+  /**
+   * CKEditor configuration
+   */
+  editorConfig = {
+    toolbar: [
+      { name: 'basicstyles', items: [ 'Bold', 'Italic' ] },
+      { name: 'clipboard', items: [ 'Cut', 'Copy', 'Paste', 'PasteText', '-', 'Undo', 'Redo' ] },
+      { name: 'document', items: ['Source'] }
+    ],
+    allowedContent: true,
+    fullPage: true,
+    startupMode: 'source',
+    height: '700px'
+  };
+
   templateEditor: FormGroup;
 
   constructor(private dtsService: DtsService, private formBuilder: FormBuilder) {

--- a/src/test/templates.ts
+++ b/src/test/templates.ts
@@ -4,7 +4,7 @@ export const templatesAll = {
     {
       templateId: '2fa85f64-5717-4562-b3fc-2c963f66afa6',
       docType: 'example_type',
-      templateKey: 'default-ce',
+      templateKey: 'NursingTemplate',
       author: 'Sue Anderson',
       createdAt: '2020-01-05T23:35:12.876Z',
       bodyUri: '/template/2fa85f64-5717-4562-b3fc-2c963f66afa6'
@@ -12,7 +12,7 @@ export const templatesAll = {
     {
       templateId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
       docType: 'enrollment',
-      templateKey: 'default-ce',
+      templateKey: 'NutritionTemplate',
       author: 'Robert Martin',
       createdAt: '2020-03-05T23:35:12.876Z',
       bodyUri: '/template/3fa85f64-5717-4562-b3fc-2c963f66afa6'
@@ -20,7 +20,7 @@ export const templatesAll = {
     {
       templateId: '1fa85f64-5717-4562-b3fc-2c963f66afa6',
       docType: 'enrollment',
-      templateKey: 'default-ce',
+      templateKey: 'PhysicalTherapyTemplate',
       author: 'Steve Giles',
       createdAt: '2020-04-05T23:35:12.876Z',
       bodyUri: '/template/2fa85f64-5717-4562-b3fc-2c963f66afa6'
@@ -34,7 +34,7 @@ export const templatesEnrollment = {
     {
       templateId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
       docType: 'enrollment',
-      templateKey: 'default-ce',
+      templateKey: 'NutritionTemplate',
       author: 'Robert Martin',
       createdAt: '2020-03-05T23:35:12.876Z',
       bodyUri: '/template/3fa85f64-5717-4562-b3fc-2c963f66afa6'
@@ -42,7 +42,7 @@ export const templatesEnrollment = {
     {
       templateId: '1fa85f64-5717-4562-b3fc-2c963f66afa6',
       docType: 'enrollment',
-      templateKey: 'default-ce',
+      templateKey: 'PhysicalTherapyTemplate',
       author: 'Steve Giles',
       createdAt: '2020-04-05T23:35:12.876Z',
       bodyUri: '/template/2fa85f64-5717-4562-b3fc-2c963f66afa6'


### PR DESCRIPTION
This update provides the ability to preview and edit document template.

As part of 2078 I wasn't planning to incorporate a preview (CEMS-2074) however I was able to find a solution for preview, so I incorporated that change into this issue.

For a two min demo see https://drive.google.com/file/d/1WYlIMnW86vQPUJ_YNQGsyXgJnlbKb_sz/view?usp=sharing.
