### PR TITLE
Only allow saving a template when in preview (wysiwyg) mode CEMS-2099

### DIFF
--- a/src/app/dts/template-editor/template-editor.component.html
+++ b/src/app/dts/template-editor/template-editor.component.html
@@ -11,9 +11,12 @@
     <mat-label>Author</mat-label>
     <input matInput type="text" formControlName="author" [readonly]="true">
   </mat-form-field>
-  <button type="submit" mat-button [disabled]="!canSave">
+  <button id="saveButton" type="submit" mat-button>
     Save
   </button>
+  <div *ngIf="templateSaved">
+    <strong>Template saved!</strong>
+  </div>
   <ckeditor formControlName="templateData"
     [config]="editorConfig">
   </ckeditor>

--- a/src/app/dts/template-editor/template-editor.component.ts
+++ b/src/app/dts/template-editor/template-editor.component.ts
@@ -17,14 +17,9 @@ export class TemplateEditorComponent implements OnInit {
   templateObject: Template;
 
   /**
-   * Enable/disable template changes
+   * Indicator to display message indicating template saved
    */
-  canSave = false;
-
-  /**
-   * Original template content
-   */
-  originalTemplate = null;
+  templateSaved = false;
 
   /**
    * CKEditor configuration
@@ -38,7 +33,22 @@ export class TemplateEditorComponent implements OnInit {
     allowedContent: true,
     fullPage: true,
     startupMode: 'source',
-    height: '700px'
+    height: '700px',
+    on: {
+      // Fired after setting the editing mode. Cannot bind to the event in the template.
+      mode(event): void {
+        const disableSaveButtonCss = ' mat-button-disabled';
+        const saveButton = document.getElementById('saveButton') as HTMLInputElement;
+        if (event.editor.mode === 'source') {
+          saveButton.disabled = true;
+          saveButton.className += disableSaveButtonCss;
+        }
+        else {
+          saveButton.disabled = false;
+          saveButton.className = saveButton.className.replace(disableSaveButtonCss, '');
+        }
+      }
+    }
   };
 
   templateEditor: FormGroup;
@@ -64,19 +74,6 @@ export class TemplateEditorComponent implements OnInit {
         this.templateEditor.controls['author'].setValue(this.templateObject.author);
       });
     }
-
-    // trap template changes
-    this.templateEditor.get('templateData').valueChanges.subscribe(val => {
-      if (this.originalTemplate) {
-        // changes made so enable save
-        // TODO - compare "val" against "originalTemplate" to determine if actual changes were made
-        this.canSave = true;
-      }
-      else {
-        // template is loaded into the editor in "preview" mode - do not enable saving
-        this.originalTemplate = val;
-      }
-    });
   }
 
   /**
@@ -88,7 +85,8 @@ export class TemplateEditorComponent implements OnInit {
       this.templateEditor.value.author,
       this.templateEditor.value.templateData
     ).subscribe( data => {
-      // TODO - will remove this at a later point
+      // TODO - remove console log and notify if save failed
+      this.templateSaved = true;
       console.log(data);
     });
   }


### PR DESCRIPTION
This update allows saving a template in “preview” (wysiwyg) mode only.

The template editor supports two modes:
- source
- preview (wysiwyg)

Because the editor only notifies of changes and makes the editor data available when in preview mode, we need to only allow the user to save a template when in preview mode.

Unfortunately there are no bindable events on the CK4 Editor control to determine when the user switches between source and preview mode.  The events available to Angular Integration is located here: https://ckeditor.com/docs/ckeditor4/latest/guide/dev_angular.html

However there is a "mode" event available from the JSON editor config.  While not ideal, because of the limitations with the CK4 Editor, this solution subscribes to the mode event from within the JSON editor config and uses the DOM to enable/disable the save button based on the event data from the mode event.

For more details see https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-mode
