### PR TITLE
Complete UI components for DTS - CEMS-2107

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,7 +5,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { createCustomElement } from '@angular/elements';
 import {CKEditorModule} from 'ckeditor4-angular';
 import { DtsComponent } from './dts/dts.component';
-import {ReactiveFormsModule} from '@angular/forms';
+import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {HttpClient, HttpClientModule} from '@angular/common/http';
 import {MatAutocompleteModule} from '@angular/material/autocomplete';
 import {MatFormFieldModule} from '@angular/material/form-field';
@@ -15,8 +15,8 @@ import {MatSelectModule} from '@angular/material/select';
 import {MatInputModule} from '@angular/material/input';
 import {MatIconModule} from '@angular/material/icon';
 import {MatTabsModule} from '@angular/material/tabs';
-
 import {TemplateEditorComponent} from './dts/template-editor/template-editor.component';
+import {MatDialogModule} from '@angular/material/dialog';
 
 @NgModule({
   declarations: [
@@ -37,13 +37,15 @@ import {TemplateEditorComponent} from './dts/template-editor/template-editor.com
     MatButtonModule,
     MatInputModule,
     MatSelectModule,
-    MatTabsModule
+    MatTabsModule,
+    MatDialogModule,
+    FormsModule
   ],
   providers: [
     HttpClient
   ],
   bootstrap: [],
-  entryComponents:[
+  entryComponents: [
     DtsComponent
   ]
 })

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -43,10 +43,7 @@ import {MatDialogModule} from '@angular/material/dialog';
   providers: [
     HttpClient
   ],
-  bootstrap: [],
-  entryComponents: [
-    DtsComponent
-  ]
+  bootstrap: []
 })
 export class AppModule {
   constructor(private injector: Injector) {}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,7 +5,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { createCustomElement } from '@angular/elements';
 import {CKEditorModule} from 'ckeditor4-angular';
 import { DtsComponent } from './dts/dts.component';
-import {FormsModule, ReactiveFormsModule} from '@angular/forms';
+import {ReactiveFormsModule} from '@angular/forms';
 import {HttpClient, HttpClientModule} from '@angular/common/http';
 import {MatAutocompleteModule} from '@angular/material/autocomplete';
 import {MatFormFieldModule} from '@angular/material/form-field';
@@ -38,8 +38,7 @@ import {MatDialogModule} from '@angular/material/dialog';
     MatInputModule,
     MatSelectModule,
     MatTabsModule,
-    MatDialogModule,
-    FormsModule
+    MatDialogModule
   ],
   providers: [
     HttpClient

--- a/src/app/dts/dts.component.html
+++ b/src/app/dts/dts.component.html
@@ -1,19 +1,73 @@
-<mat-tab-group (selectedTabChange)="tabClick($event)">
-  <mat-tab label="Template">
-    <ngx-datatable
-      class="material striped"
-      [rows]="rows | async"
-      [columns]="columns"
-      [headerHeight]="50"
-      [footerHeight]="50"
-      [rowHeight]="50"
-      (activate)="rowClick($event)"
-      [messages]="{ emptyMessage: 'No templates found.' }"
-      [sorts]="[ {prop: 'author', dir: 'asc'} ]">
-    </ngx-datatable>
-  </mat-tab>
-  <mat-tab label="Edit" [disabled]="selectedTemplate == null">
-    <app-template-editor *ngIf="showEditor" [templateObject]="selectedTemplate">
-    </app-template-editor>
-  </mat-tab>
-</mat-tab-group>
+<form [formGroup]="dtsForm">
+  <button type="button" (click)="newTemplate()" mat-button>
+    <b>&#43;</b>
+  </button>
+  <mat-form-field class="filterby-form-field">
+    <input class="filterBy" matInput type="text" formControlName="templateFilter" placeholder="Type to filter by key or author...">
+    <button mat-button *ngIf="dtsForm.value.templateFilter" matSuffix mat-icon-button aria-label="Clear" (click)="dtsForm.controls['templateFilter'].setValue('')">
+      &#120;
+    </button>
+  </mat-form-field>
+  <ngx-datatable
+    #templateTable
+    class="material striped"
+    [rows]="rows | async"
+    [headerHeight]="50"
+    [footerHeight]="50"
+    [rowHeight]="50"
+    [limit]="2"
+    (activate)="rowClick($event)"
+    [messages]="{ emptyMessage: 'No templates found.' }"
+    [columnMode]="'flex'"
+    [sorts]="[ {prop: 'templateKey', dir: 'asc'} ]">
+
+    <!-- Row Detail Template -->
+    <ngx-datatable-row-detail [rowHeight]="100" #myDetailRow >
+      <ng-template let-row="row" let-expanded="expanded" ngx-datatable-row-detail-template>
+        <table>
+          <tr>
+            <td>Template Id</td>
+            <td>{{ row.templateId }}</td>
+          </tr>
+          <tr>
+            <td>Body Uri</td>
+            <td>{{ row.bodyUri }}</td>
+          </tr>
+          <tr>
+            <td>Document Type</td>
+            <td>{{ row.docType }}</td>
+          </tr>
+        </table>
+      </ng-template>
+    </ngx-datatable-row-detail>
+
+    <ngx-datatable-column
+      [width]="50"
+      [resizeable]="false"
+      [sortable]="false"
+      [draggable]="false"
+      [canAutoResize]="false">
+      <ng-template let-row="row" let-expanded="expanded" ngx-datatable-cell-template>
+        <a href="javascript:void(0)"
+          [class.datatable-icon-right]="!expanded"
+          [class.datatable-icon-down]="expanded"
+          title="Expand/Collapse Row"
+          (click)="toggleExpandRow(row)">
+        </a>
+      </ng-template>
+    </ngx-datatable-column>
+
+    <ngx-datatable-column name="Template Key" prop="templateKey" [flexGrow]="1" >
+    </ngx-datatable-column>
+
+    <ngx-datatable-column name="Author" prop="author"  [canAutoResize]="false" minWidth="300">
+    </ngx-datatable-column>
+
+    <ngx-datatable-column name="Date/Time" prop="createdAt"   [canAutoResize]="false" minWidth="150">
+      <ng-template let-value="value" ngx-datatable-cell-template>
+        {{ value | date:'short' }}
+      </ng-template>
+    </ngx-datatable-column>
+
+  </ngx-datatable>
+</form>

--- a/src/app/dts/dts.component.html
+++ b/src/app/dts/dts.component.html
@@ -15,7 +15,7 @@
     [headerHeight]="50"
     [footerHeight]="50"
     [rowHeight]="50"
-    [limit]="2"
+    [limit]="10"
     (activate)="rowClick($event)"
     [messages]="{ emptyMessage: 'No templates found.' }"
     [columnMode]="'flex'"

--- a/src/app/dts/dts.component.html
+++ b/src/app/dts/dts.component.html
@@ -4,7 +4,7 @@
   </button>
   <mat-form-field class="filterby-form-field">
     <input class="filterBy" matInput type="text" formControlName="templateFilter" placeholder="Type to filter by key or author...">
-    <button mat-button *ngIf="dtsForm.value.templateFilter" matSuffix mat-icon-button aria-label="Clear" (click)="dtsForm.controls['templateFilter'].setValue('')">
+    <button mat-button *ngIf="dtsForm.value.templateFilter" matSuffix mat-icon-button aria-label="Clear" (click)="dtsForm.reset()">
       &#120;
     </button>
   </mat-form-field>
@@ -49,8 +49,8 @@
       [canAutoResize]="false">
       <ng-template let-row="row" let-expanded="expanded" ngx-datatable-cell-template>
         <a href="javascript:void(0)"
-          [class.datatable-icon-right]="!expanded"
-          [class.datatable-icon-down]="expanded"
+          [class.arrow-right]="!expanded"
+          [class.arrow-down]="expanded"
           title="Expand/Collapse Row"
           (click)="toggleExpandRow(row)">
         </a>

--- a/src/app/dts/dts.component.scss
+++ b/src/app/dts/dts.component.scss
@@ -1,11 +1,15 @@
-.user-list {
-  .nav-link, .nav-link:hover {
-    .is-active-icon {
-      color: green;
-    }
-  }
+.filterby-form-field {
+  width: 30em;
+}
 
-  .is-active-icon {
-    color: green;
-  }
+td:first-child {
+  width: 10em;
+}
+
+a:link {
+  text-decoration: none;
+}
+
+a:visited {
+  text-decoration: none;
 }

--- a/src/app/dts/dts.component.scss
+++ b/src/app/dts/dts.component.scss
@@ -13,3 +13,30 @@ a:link {
 a:visited {
   text-decoration: none;
 }
+
+table {
+  padding-left: 5em;
+  width: 100%;
+}
+
+.arrow-right {
+  border: solid black;
+  border-width: 0 1px 1px 0;
+  display: inline-block;
+  margin-top: 6px;
+  padding: 3px;
+  transform: rotate(-45deg);
+  -webkit-transform: rotate(-45deg);
+}
+
+.arrow-down {
+  border: solid black;
+  border-width: 0 1px 1px 0;
+  display: inline-block;
+  margin-top: 6px;
+  padding: 3px;
+  transform: rotate(45deg);
+  -webkit-transform: rotate(45deg);
+}
+
+

--- a/src/app/dts/dts.component.spec.ts
+++ b/src/app/dts/dts.component.spec.ts
@@ -6,6 +6,8 @@ import {of} from 'rxjs';
 import {NgxDatatableModule} from '@swimlane/ngx-datatable';
 import {templatesAll, templatesEnrollment} from '../../test/templates';
 import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
+import {MatDialog, MatDialogModule} from '@angular/material/dialog';
+import {FormBuilder} from '@angular/forms';
 
 describe('DtsComponent', () => {
   let component: DtsComponent;
@@ -24,7 +26,8 @@ describe('DtsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
-        NgxDatatableModule
+        NgxDatatableModule,
+        MatDialogModule
       ],
       declarations: [
         DtsComponent
@@ -32,7 +35,9 @@ describe('DtsComponent', () => {
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
       providers: [
         HttpClient,
-        HttpHandler
+        HttpHandler,
+        MatDialog,
+        FormBuilder
       ]
     })
     .compileComponents();
@@ -51,9 +56,8 @@ describe('DtsComponent', () => {
     createComponent();
 
     const gridData = fixture.debugElement.nativeElement.querySelectorAll('.datatable-body');
-    expect(gridData[0].textContent).toEqual('Robert MartinNutritionTemplate3fa85f64-5717-4562-b3fc-2c963f66afa62020-03-05T23:' +
-      '35:12.876ZSteve GilesPhysicalTherapyTemplate1fa85f64-5717-4562-b3fc-2c963f66afa62020-04-05T23:35:12.876ZSue AndersonNursingTem' +
-      'plate2fa85f64-5717-4562-b3fc-2c963f66afa62020-01-05T23:35:12.876Z');
+    expect(gridData[0].textContent).toEqual('NursingTemplateSue Anderson 1/5/20, 6:35 PM NutritionTemplateRobert Martin ' +
+      '3/5/20, 6:35 PM ');
   });
 
   it('should display a list of templates by document type', ()  => {
@@ -61,8 +65,8 @@ describe('DtsComponent', () => {
     createComponent();
 
     const gridData = fixture.debugElement.nativeElement.querySelectorAll('.datatable-body');
-    expect(gridData[0].textContent).toEqual('Robert MartinNutritionTemplate3fa85f64-5717-4562-b3fc-2c963f66afa62020-03-05T23:' +
-      '35:12.876ZSteve GilesPhysicalTherapyTemplate1fa85f64-5717-4562-b3fc-2c963f66afa62020-04-05T23:35:12.876Z');
+    expect(gridData[0].textContent).toEqual('NutritionTemplateRobert Martin 3/5/20, 6:35 PM PhysicalTherapyTemplateSteve Giles ' +
+      '4/5/20, 7:35 PM ');
   });
 
 });

--- a/src/app/dts/dts.component.spec.ts
+++ b/src/app/dts/dts.component.spec.ts
@@ -7,7 +7,7 @@ import {NgxDatatableModule} from '@swimlane/ngx-datatable';
 import {templatesAll, templatesEnrollment} from '../../test/templates';
 import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
 import {MatDialog, MatDialogModule} from '@angular/material/dialog';
-import {FormBuilder} from '@angular/forms';
+import {FormBuilder, ReactiveFormsModule} from '@angular/forms';
 
 describe('DtsComponent', () => {
   let component: DtsComponent;
@@ -27,7 +27,8 @@ describe('DtsComponent', () => {
     await TestBed.configureTestingModule({
       imports: [
         NgxDatatableModule,
-        MatDialogModule
+        MatDialogModule,
+        ReactiveFormsModule
       ],
       declarations: [
         DtsComponent
@@ -56,8 +57,8 @@ describe('DtsComponent', () => {
     createComponent();
 
     const gridData = fixture.debugElement.nativeElement.querySelectorAll('.datatable-body');
-    expect(gridData[0].textContent).toEqual('NursingTemplateSue Anderson 1/5/20, 6:35 PM NutritionTemplateRobert Martin ' +
-      '3/5/20, 6:35 PM ');
+    expect(gridData[0].textContent).toEqual('NursingTemplateSue Anderson 1/5/20, 6:35 PM NutritionTemplateRobert Martin 3/5/20,' +
+      ' 6:35 PM PhysicalTherapyTemplateSteve Giles 4/5/20, 7:35 PM ');
   });
 
   it('should display a list of templates by document type', ()  => {

--- a/src/app/dts/dts.service.ts
+++ b/src/app/dts/dts.service.ts
@@ -53,6 +53,8 @@ export class DtsService {
    * @param templateKey unique template identifier
    */
   public getTemplateByKey(documentType: string, templateKey: string): Observable<string> {
+    templateKey = encodeURI(templateKey);
+
     const url =  `${this.url}template/${documentType}/${templateKey}`;
 
     return this.http.get(url, {responseType: 'text'});
@@ -65,6 +67,8 @@ export class DtsService {
    * @param dataKey unique data identifier
    */
   public renderTemplate(documentType: string, templateKey: string, dataKey: string): Observable<string> {
+    templateKey = encodeURI(templateKey);
+
     const url =  `${this.url}render/${documentType}/${templateKey}/${dataKey}`;
 
     return this.http.get(url, {responseType: 'text'});

--- a/src/app/dts/template-editor/template-editor.component.html
+++ b/src/app/dts/template-editor/template-editor.component.html
@@ -1,32 +1,35 @@
 <form [formGroup]="templateEditor" (ngSubmit)="onSubmit()">
-  <mat-form-field>
-    <mat-label>Template Key</mat-label>
-    <input matInput type="text" formControlName="templateKey" [readonly]="true">
-  </mat-form-field>
-  <mat-form-field class="full-width">
-    <mat-label>Template Id</mat-label>
-    <input matInput type="text" formControlName="templateId" [readonly]="true">
-  </mat-form-field>
-  <mat-form-field>
-    <mat-label>Author</mat-label>
-    <input matInput type="text" formControlName="author" [readonly]="true">
-  </mat-form-field>
-  <div>
-    <mat-form-field>
-      <mat-label>Data Key</mat-label>
-      <input matInput type="text" formControlName="dataKey">
+  <div class="flex-row">
+    <mat-form-field class="templateKey">
+      <mat-label>Template Key</mat-label>
+      <input matInput type="text" formControlName="templateKey" [readonly]="existingTemplate">
     </mat-form-field>
-    <button [disabled]="!templateEditor.value.dataKey" (click)="renderTemplate()" type="button" mat-button>
-      Preview
+    <div class="push" >
+      <mat-form-field class="dataKey">
+        <mat-label>Data Key</mat-label>
+        <input matInput type="text" formControlName="dataKey">
+      </mat-form-field>
+      <button [disabled]="!templateEditor.value.dataKey" (click)="renderTemplate()" type="button" mat-button>
+        Preview
+      </button>
+    </div>
+  </div>
+  <div class="flex-row">
+    <button type="button" (click)="copyTemplate()" [disabled]="dirty" mat-button>
+      Copy
+    </button>
+    <button type="button" (click)="discardChangesAndClose()" mat-button>
+      Close
+    </button>
+    <div class="statusMessage" *ngIf="statusMessage != ''">
+      {{ statusMessage }}
+    </div>
+    <button id="saveButton" type="submit" [disabled]="!dirty || templateEditor.invalid" class="push" mat-button>
+      Save
     </button>
   </div>
-  <button id="saveButton" type="submit" mat-button>
-    Save
-  </button>
-  <div *ngIf="templateSaved">
-    <strong>Template saved!</strong>
-  </div>
-  <ckeditor formControlName="templateData"
+
+  <ckeditor formControlName="templateData" (change)="editorChanged($event)"
     [config]="editorConfig">
   </ckeditor>
 </form>

--- a/src/app/dts/template-editor/template-editor.component.scss
+++ b/src/app/dts/template-editor/template-editor.component.scss
@@ -1,3 +1,33 @@
-.full-width {
+.button-group {
+  display: flex;
+}
+
+.flexbox-spacebetween {
+  justify-content: space-between;
+}
+
+.item {
+  box-sizing: border-box;
+  padding: 1em;
+}
+
+.flex-row {
+  display: flex;
+}
+
+.push {
+  margin-left: auto;
+}
+
+.templateKey {
   width: 400px;
+}
+
+.dataKey {
+  width: 300px;
+}
+
+.statusMessage {
+  margin-top:10px;
+  padding-left: 5em;
 }

--- a/src/app/dts/template-editor/template-editor.component.scss
+++ b/src/app/dts/template-editor/template-editor.component.scss
@@ -1,16 +1,3 @@
-.button-group {
-  display: flex;
-}
-
-.flexbox-spacebetween {
-  justify-content: space-between;
-}
-
-.item {
-  box-sizing: border-box;
-  padding: 1em;
-}
-
 .flex-row {
   display: flex;
 }

--- a/src/app/dts/template-editor/template-editor.component.spec.ts
+++ b/src/app/dts/template-editor/template-editor.component.spec.ts
@@ -1,4 +1,4 @@
-import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {ComponentFixture, fakeAsync, TestBed} from '@angular/core/testing';
 import {TemplateEditorComponent} from './template-editor.component';
 import {FormBuilder, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {HttpClient, HttpHandler} from '@angular/common/http';
@@ -8,11 +8,18 @@ import {DtsService} from '../dts.service';
 import {template} from '../../../test/template';
 import {CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA} from '@angular/core';
 import {CKEditorModule} from 'ckeditor4-angular';
+import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
 
 describe('TemplateEditorComponent', () => {
   let component: TemplateEditorComponent;
   let fixture: ComponentFixture<TemplateEditorComponent>;
   let dtsService: DtsService;
+
+  const dialogMock = {
+    disableClose: true,
+    close: () => {},
+    backdropClick: () => of({})
+  };
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -31,7 +38,9 @@ describe('TemplateEditorComponent', () => {
       providers: [
         HttpClient,
         HttpHandler,
-        FormBuilder
+        FormBuilder,
+        {provide: MAT_DIALOG_DATA, useValue: {}},
+        {provide: MatDialogRef, useValue: dialogMock}
       ]
     })
     .compileComponents();
@@ -42,6 +51,8 @@ describe('TemplateEditorComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(TemplateEditorComponent);
     component = fixture.componentInstance;
+
+    spyOn(window, 'confirm').and.returnValue(true);
 
     component.editorConfig = {
       toolbar: [
@@ -64,26 +75,58 @@ describe('TemplateEditorComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it('should create',  fakeAsync(() => {
     expect(component).toBeTruthy();
+  }));
+
+  it('should initialize and allow creating a new template', (done) => {
+    const expectedBody = `<p><br></p>`;
+
+    // wait for editor to display the default template
+    setTimeout(($element) => {
+      // switch display mode from code to wysiwyg
+      const sourceButton = fixture.debugElement.nativeElement.querySelector('.cke_button__source');
+      sourceButton.click();
+
+      // get the template content from the CK Editor rendered in an iFrame
+      const editorData = fixture.debugElement.nativeElement.querySelectorAll('.cke_wysiwyg_frame');
+      const content = editorData[0].contentDocument;
+
+      // verify the CK Editor control has displayed the default template makrup
+      expect(content.body.innerHTML).toEqual(expectedBody);
+      // expect(component.dirty).toBeFalse();
+
+      done();
+    }, 500);
   });
 
-  it('should get a template by template key on initialization', fakeAsync(() => {
+  it('should get a template by template key on initialization and allow edit', (done) => {
+    const expectedBody = `<div id="container" class="page"><p style="text-align:center;">Enrollment #: <span class="char-style-override-6">{{ enrollmentId }}</span></p><p><span class="char-style-override-2" style="line-height: 1.2;">Course Certificate</span></p><p><span class="char-style-override-3">This is to certify</span></p><p><span class="char-style-override-1">{{ student.firstName }} {{ student.lastName }}&nbsp;-&nbsp;{{~#each student.licenses as |license|~}}{{license.state}} {{license.type}} {{license.number}}{{#unless @last}}; {{/unless}}{{~/each~}}</span></p><p><span>has successfully completed </span><span class="char-style-override-1">{{ course.hours }} contact hours</span><span>{{#if (eq course.format 'live')}}Live Continuing Education{{else}}continuing education online training{{/if}} on the topic of:</span></p><p><span class="char-style-override-4">{{ course.name }}</span><br>{{#if course.authors}}{{#with course.authors as |authors|}}Course Speakers:{{#each authors~}}{{this}}{{#unless @last}} | {{/unless}}{{~/each}}{{/with}}{{/if}}</p><p><span>Presented by HomeCEUConnection.com, 5048 Tennyson Pkwy, Suite 200 Plano TX 75024</span></p><p><span>Course completed on {{ completionDate }}</span></p></div>`;
     spyOn(dtsService, 'getTemplateByKey').and.returnValue(of(template));
 
-    component.templateObject.docType = 'dummyDocType';
+    component.templateObject.docType = 'enrollment';
     component.templateObject.templateKey = 'dummyTemplateKey';
     component.ngOnInit();
-    tick();
 
     // verify the form control has received the template data
-    expect(component.templateEditor.controls['templateData'].value).toEqual(template);
+    expect(component.templateEditor.controls.templateData.value).toEqual(template);
 
-    // When executing the unit test you can see the template text displayed in the editor so the functionality is working correctly,
-    // however at this point in time the ckeditor control is not yet rendered. Eventually it is rendered as a textarea element with nine
-    // attributes however there is no inner HTML representing the template text so it's currently not possible to verify the editor
-    // displayed with text.
-    // const templateData = fixture.debugElement.nativeElement.querySelectorAll('.cke_source');
-  }));
+    // wait for editor to display the template
+    setTimeout(() => {
+      // switch display mode from code to wysiwyg
+      const sourceButton = fixture.debugElement.nativeElement.querySelector('.cke_button__source');
+      sourceButton.click();
+
+      // get the template content from the CK Editor rendered in an iFrame
+      const editorData = fixture.debugElement.nativeElement.querySelectorAll('.cke_wysiwyg_frame');
+      const content = editorData[0].contentDocument;
+
+      // verify the CK Editor control has received and displayed the template data
+      expect(content.body.innerHTML).toEqual(expectedBody);
+      expect(component.dirty).toBeFalse();
+
+      done();
+    }, 500);
+  });
 
 });

--- a/src/app/dts/template-editor/template-editor.component.spec.ts
+++ b/src/app/dts/template-editor/template-editor.component.spec.ts
@@ -1,6 +1,6 @@
-import {ComponentFixture, fakeAsync, TestBed} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TemplateEditorComponent} from './template-editor.component';
-import {FormBuilder, FormsModule, ReactiveFormsModule} from '@angular/forms';
+import {FormBuilder, ReactiveFormsModule} from '@angular/forms';
 import {HttpClient, HttpHandler} from '@angular/common/http';
 import {Template} from '../template.types';
 import {of} from 'rxjs';
@@ -25,7 +25,6 @@ describe('TemplateEditorComponent', () => {
     await TestBed.configureTestingModule({
       imports: [
         ReactiveFormsModule,
-        FormsModule,
         CKEditorModule
       ],
       declarations: [
@@ -75,9 +74,9 @@ describe('TemplateEditorComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should create',  fakeAsync(() => {
+  it('should create',  () => {
     expect(component).toBeTruthy();
-  }));
+  });
 
   it('should initialize and allow creating a new template', (done) => {
     const expectedBody = `<p><br></p>`;

--- a/src/app/dts/template-editor/template-editor.component.ts
+++ b/src/app/dts/template-editor/template-editor.component.ts
@@ -1,7 +1,8 @@
-import {Component, Input, OnInit} from '@angular/core';
-import {FormBuilder, FormControl, FormGroup} from '@angular/forms';
+import {Component, HostListener, Inject, OnInit} from '@angular/core';
+import {FormBuilder, FormGroup, Validators} from '@angular/forms';
 import {DtsService} from '../dts.service';
 import {Template} from '../template.types';
+import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
 
 @Component({
   selector: 'app-template-editor',
@@ -9,17 +10,20 @@ import {Template} from '../template.types';
   styleUrls: ['./template-editor.component.scss']
 })
 export class TemplateEditorComponent implements OnInit {
+  /**
+   * Either creating or editing a template
+   */
+  existingTemplate = true;
 
   /**
-   * Template to edit
+   * Used to display status messages
    */
-  @Input()
-  templateObject: Template;
+  statusMessage = '';
 
   /**
-   * Indicator to display message indicating template saved
+   * Changes made to template
    */
-  templateSaved = false;
+  dirty = false;
 
   /**
    * CKEditor configuration
@@ -53,10 +57,25 @@ export class TemplateEditorComponent implements OnInit {
 
   templateEditor: FormGroup;
 
-  constructor(private dtsService: DtsService, private formBuilder: FormBuilder) {
+  /**
+   * Check for changes when closing modal via 'esc'
+   */
+  @HostListener('window:keyup.esc') onKeyUp(): void {
+    this.discardChangesAndClose();
+  }
+
+  @HostListener('window:beforeunload', ['$event']) unloadHandler(event: Event): void {
+    event.returnValue = false;
+  }
+
+  constructor(@Inject(MAT_DIALOG_DATA) public templateObject: Template,
+              private dtsService: DtsService,
+              public dialogRef: MatDialogRef<TemplateEditorComponent>,
+              private formBuilder: FormBuilder) {
+
     this.templateEditor = this.formBuilder.group({
       templateData: '',
-      templateKey: '',
+      templateKey: ['', [Validators.required, Validators.maxLength(40)]], // VARCHAR(255) in the database
       templateId: '',
       author: '',
       dataKey: ''
@@ -68,27 +87,46 @@ export class TemplateEditorComponent implements OnInit {
    */
   ngOnInit(): void {
     if (this.templateObject.docType && this.templateObject.templateKey) {
+      this.templateEditor.controls.templateKey.setValue(this.templateObject.templateKey);
+      this.templateEditor.controls.templateId.setValue(this.templateObject.templateId);
+      this.templateEditor.controls.author.setValue(this.templateObject.author);
+
+      // retrieve template content for existing template
       this.dtsService.getTemplateByKey(this.templateObject.docType, this.templateObject.templateKey).subscribe(data => {
-        this.templateEditor.controls['templateData'].setValue(data, { emitEvent: false });
-        this.templateEditor.controls['templateKey'].setValue(this.templateObject.templateKey);
-        this.templateEditor.controls['templateId'].setValue(this.templateObject.templateId);
-        this.templateEditor.controls['author'].setValue(this.templateObject.author);
+        this.templateEditor.controls.templateData.setValue(data, { emitEvent: false });
+        this.dirty = false;
+        this.existingTemplate = true;
       });
     }
+    else {
+      // creating a new template
+      this.dirty = true;
+      this.existingTemplate = false;
+    }
+
+    // require user to confirm closing the dialog with unsaved changes
+    this.dialogRef.disableClose = true;
+    this.dialogRef.backdropClick().subscribe(() => {
+      this.discardChangesAndClose();
+    });
   }
 
   /**
    * Saves the template
    */
   onSubmit(): void {
+    // todo - when creating a new template need to verify the template key entered by the user does not currently exist in the db
+    //  otherwise would overwrite existing template
+
     this.dtsService.saveTemplate(
       this.templateEditor.value.templateKey,
       this.templateEditor.value.author,
       this.templateEditor.value.templateData
     ).subscribe( data => {
-      // TODO - remove console log and notify if save failed
-      this.templateSaved = true;
-      console.log(data);
+      // TODO - notify if save failed
+      this.dirty = false;
+      this.existingTemplate = true;
+      this.statusMessage = 'Template saved';
     });
   }
 
@@ -104,6 +142,49 @@ export class TemplateEditorComponent implements OnInit {
           modal.document.write(certificate);
           modal.document.close();
       });
+    }
+  }
+
+  /**
+   * Creates a new template from the existing template
+   */
+  copyTemplate(): void {
+    // get the template prior to resetting the form
+    const templateData = this.templateEditor.controls.templateData.value;
+
+    this.templateEditor.reset();
+
+    // copy the previous template into the form
+    this.templateEditor.controls.templateData.setValue(templateData);
+
+    // todo - need a way to get the user name for the currently logged in user
+    this.templateEditor.controls.author.setValue('Unknown User');
+
+    this.existingTemplate = false;  // creating a new template
+    this.dirty = true;              // needs saving
+  }
+
+  /**
+   * Fires when the content of the editor has changed - used to indicate when user has made changes
+   * @param event
+   */
+  editorChanged(event): void {
+    this.dirty = true;
+    this.statusMessage = '';
+  }
+
+  /**
+   * Prompts the user to confirm closing the dialog with unsaved changes
+   */
+  discardChangesAndClose(): void {
+    if (this.dirty) {
+      const cn = confirm('Discard unsaved changes and close?');
+      if (cn) {
+        this.dialogRef.close();
+      }
+    }
+    else {
+      this.dialogRef.close();
     }
   }
 }

--- a/src/app/dts/template-editor/template-editor.component.ts
+++ b/src/app/dts/template-editor/template-editor.component.ts
@@ -87,9 +87,7 @@ export class TemplateEditorComponent implements OnInit {
    */
   ngOnInit(): void {
     if (this.templateObject.docType && this.templateObject.templateKey) {
-      this.templateEditor.controls.templateKey.setValue(this.templateObject.templateKey);
-      this.templateEditor.controls.templateId.setValue(this.templateObject.templateId);
-      this.templateEditor.controls.author.setValue(this.templateObject.author);
+      this.templateEditor.patchValue(this.templateObject)
 
       // retrieve template content for existing template
       this.dtsService.getTemplateByKey(this.templateObject.docType, this.templateObject.templateKey).subscribe(data => {


### PR DESCRIPTION
This update completes the task of providing all the UI components to support managing templates.

The following two features are currently provided in the UI however the business logic is not complete:
- Saving a new template
- Filtering a list of existing templates

The following changes were implemented in this task
- A selected a template is now launched in Material Dialog instead of a Material Tab Control
- The grid displaying a list of templates now has an collapsed/expandable column to display template details.
- The displayed template date/time is now formatted to a human readable, short date/time.
- Added a UI element to filter templates.
- Added a UI element to add a new template.
- Added logic track when changes were made to a template, and to prompt the user to confirm closing the modal when they attempt to navigate away with unsaved changes.
- Added logic to copy and create a new template from an existing template.
- Fixed a previous issue with an editor component test where I wasn’t able to verify that the editor displayed a template.

Will be giving a demo of this functionality on 11/2 at 2:00 PM CST 