### PR TITLE
Improve editor control event listener CEMS-2117

### DIFF
--- a/src/app/dts/dts.component.spec.ts
+++ b/src/app/dts/dts.component.spec.ts
@@ -1,4 +1,4 @@
-import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {ComponentFixture, inject, TestBed} from '@angular/core/testing';
 import {DtsComponent} from './dts.component';
 import {HttpClient, HttpHandler} from '@angular/common/http';
 import {DtsService} from './dts.service';
@@ -12,7 +12,6 @@ import {FormBuilder, ReactiveFormsModule} from '@angular/forms';
 describe('DtsComponent', () => {
   let component: DtsComponent;
   let fixture: ComponentFixture<DtsComponent>;
-  let dtsService: DtsService;
 
   /**
    * Create the component which calls the constructor to populate the data grid
@@ -42,32 +41,30 @@ describe('DtsComponent', () => {
       ]
     })
     .compileComponents();
-
-    dtsService = TestBed.get(DtsService);
   });
 
-  it('should create', () => {
+  it('should create', inject([DtsService], (dtsService: DtsService) => {
     spyOn(dtsService, 'getTemplates').and.returnValue(of(null));
     createComponent();
     expect(component).toBeTruthy();
-  });
+  }));
 
-  it('should display a list of all available templates', ()  => {
+  it('should display a list of all available templates', inject([DtsService], (dtsService: DtsService) => {
     dtsService.getTemplates = jasmine.createSpy().and.returnValue(of(templatesAll.items));
     createComponent();
 
     const gridData = fixture.debugElement.nativeElement.querySelectorAll('.datatable-body');
     expect(gridData[0].textContent).toEqual('NursingTemplateSue Anderson 1/5/20, 6:35 PM NutritionTemplateRobert Martin 3/5/20,' +
       ' 6:35 PM PhysicalTherapyTemplateSteve Giles 4/5/20, 7:35 PM ');
-  });
+  }));
 
-  it('should display a list of templates by document type', ()  => {
+  it('should display a list of templates by document type', inject([DtsService], (dtsService: DtsService) => {
     dtsService.getTemplates = jasmine.createSpy().and.returnValue(of(templatesEnrollment.items));
     createComponent();
 
     const gridData = fixture.debugElement.nativeElement.querySelectorAll('.datatable-body');
     expect(gridData[0].textContent).toEqual('NutritionTemplateRobert Martin 3/5/20, 6:35 PM PhysicalTherapyTemplateSteve Giles ' +
       '4/5/20, 7:35 PM ');
-  });
+  }));
 
 });

--- a/src/app/dts/template-editor/template-editor.component.html
+++ b/src/app/dts/template-editor/template-editor.component.html
@@ -24,12 +24,12 @@
     <div class="statusMessage" *ngIf="statusMessage != ''">
       {{ statusMessage }}
     </div>
-    <button id="saveButton" type="submit" [disabled]="!dirty || templateEditor.invalid" class="push" mat-button>
+    <button id="saveButton" type="submit" [disabled]="!dirty || templateEditor.invalid || editorControl.mode == 'source'" class="push" mat-button>
       Save
     </button>
   </div>
 
-  <ckeditor formControlName="templateData" (change)="editorChanged($event)"
+  <ckeditor formControlName="templateData" (change)="editorChanged($event)" (ready)="editorReady($event)"
     [config]="editorConfig">
   </ckeditor>
 </form>

--- a/src/app/dts/template-editor/template-editor.component.spec.ts
+++ b/src/app/dts/template-editor/template-editor.component.spec.ts
@@ -62,11 +62,7 @@ describe('TemplateEditorComponent', () => {
       allowedContent: true,
       fullPage: true,
       startupMode: 'source',
-      height: '700px',
-      on: {
-        mode(event): void {
-        }
-      }
+      height: '700px'
     };
 
     component.templateObject = {} as Template;

--- a/src/app/dts/template-editor/template-editor.component.spec.ts
+++ b/src/app/dts/template-editor/template-editor.component.spec.ts
@@ -53,18 +53,6 @@ describe('TemplateEditorComponent', () => {
 
     spyOn(window, 'confirm').and.returnValue(true);
 
-    component.editorConfig = {
-      toolbar: [
-        { name: 'basicstyles', items: [ 'Bold', 'Italic' ] },
-        { name: 'clipboard', items: [ 'Cut', 'Copy', 'Paste', 'PasteText', '-', 'Undo', 'Redo' ] },
-        { name: 'document', items: ['Source'] }
-      ],
-      allowedContent: true,
-      fullPage: true,
-      startupMode: 'source',
-      height: '700px'
-    };
-
     component.templateObject = {} as Template;
 
     fixture.detectChanges();

--- a/src/app/dts/template-editor/template-editor.component.ts
+++ b/src/app/dts/template-editor/template-editor.component.ts
@@ -3,6 +3,7 @@ import {FormBuilder, FormGroup, Validators} from '@angular/forms';
 import {DtsService} from '../dts.service';
 import {Template} from '../template.types';
 import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
+import {CKEditor4} from 'ckeditor4-angular';
 
 @Component({
   selector: 'app-template-editor',
@@ -26,6 +27,11 @@ export class TemplateEditorComponent implements OnInit {
   dirty = false;
 
   /**
+   * Provides access to properties and methods of the CkEditor
+   */
+  editorControl: CKEditor4.Editor;
+
+  /**
    * CKEditor configuration
    */
   editorConfig = {
@@ -37,22 +43,7 @@ export class TemplateEditorComponent implements OnInit {
     allowedContent: true,
     fullPage: true,
     startupMode: 'source',
-    height: '700px',
-    on: {
-      // Fired after setting the editing mode. Cannot bind to the event in the template.
-      mode(event): void {
-        const disableSaveButtonCss = ' mat-button-disabled';
-        const saveButton = document.getElementById('saveButton') as HTMLInputElement;
-        if (event.editor.mode === 'source') {
-          saveButton.disabled = true;
-          saveButton.className += disableSaveButtonCss;
-        }
-        else {
-          saveButton.disabled = false;
-          saveButton.className = saveButton.className.replace(disableSaveButtonCss, '');
-        }
-      }
-    }
+    height: '700px'
   };
 
   templateEditor: FormGroup;
@@ -164,7 +155,7 @@ export class TemplateEditorComponent implements OnInit {
 
   /**
    * Fires when the content of the editor has changed - used to indicate when user has made changes
-   * @param event
+   * @param event information
    */
   editorChanged(event): void {
     this.dirty = true;
@@ -184,5 +175,13 @@ export class TemplateEditorComponent implements OnInit {
     else {
       this.dialogRef.close();
     }
+  }
+
+  /**
+   * CkEditor is loaded and ready
+   * @param event information
+   */
+  editorReady(event): void {
+    this.editorControl = event.editor;
   }
 }

--- a/src/app/dts/template-editor/template-editor.component.ts
+++ b/src/app/dts/template-editor/template-editor.component.ts
@@ -78,7 +78,7 @@ export class TemplateEditorComponent implements OnInit {
    */
   ngOnInit(): void {
     if (this.templateObject.docType && this.templateObject.templateKey) {
-      this.templateEditor.patchValue(this.templateObject)
+      this.templateEditor.patchValue(this.templateObject);
 
       // retrieve template content for existing template
       this.dtsService.getTemplateByKey(this.templateObject.docType, this.templateObject.templateKey).subscribe(data => {


### PR DESCRIPTION
This is an internal technical improvement which improves how we listen for events from the CK Editor control.

With this change, we now 
- Gain access to the editor control when the control has completed initializing and loading.
- Listen for events by subscribing to the events in the editorReady() method.  For example, if we wanted to determine when the user changes between source and wysiwyg modes and programmatically perform an action, we'd add the following code to the editorReady() method.

`    event.editor.on('mode', (eventData) => {
       if (eventData.editor.mode === 'source') {
         // user switched to source mode
       }
       else {
         // user switched to wysiwyg mode
       }
     });`
