### PR TITLE
Create frontend dts build output files CEMS-2158

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Run `ng generate component component-name` to generate a new component. You can 
 
 ## Build
 
-- Run `run npm build:elements`
+- Run `run npm build:dts`
 - Copy `\elements\frontend-lib.js` and `\dist\frontend-lib\styles.css` to the Server where the element is exposed.
 
 ## Running unit tests

--- a/angular.json
+++ b/angular.json
@@ -33,22 +33,6 @@
             "scripts": []
           },
           "configurations": {
-            "staging": {
-              "fileReplacements": [
-                {
-                  "replace": "src/environments/environment.ts",
-                  "with": "src/environments/environment.stage.ts"
-                }
-              ],
-              "optimization": false,
-              "outputHashing": "all",
-              "sourceMap": false,
-              "extractCss": true,
-              "namedChunks": false,
-              "extractLicenses": true,
-              "vendorChunk": false,
-              "buildOptimizer": false
-            },
             "production": {
               "fileReplacements": [
                 {
@@ -85,9 +69,6 @@
             "browserTarget": "frontend-lib:build"
           },
           "configurations": {
-            "staging": {
-              "browserTarget": "frontend-lib:build:staging"
-            },
             "production": {
               "browserTarget": "frontend-lib:build:production"
             }
@@ -137,9 +118,6 @@
             "devServerTarget": "frontend-lib:serve"
           },
           "configurations": {
-            "staging": {
-              "devServerTarget": "frontend-lib:serve:staging"
-            },
             "production": {
               "devServerTarget": "frontend-lib:serve:production"
             }

--- a/angular.json
+++ b/angular.json
@@ -33,6 +33,22 @@
             "scripts": []
           },
           "configurations": {
+            "staging": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.stage.ts"
+                }
+              ],
+              "optimization": false,
+              "outputHashing": "all",
+              "sourceMap": false,
+              "extractCss": true,
+              "namedChunks": false,
+              "extractLicenses": true,
+              "vendorChunk": false,
+              "buildOptimizer": false
+            },
             "production": {
               "fileReplacements": [
                 {
@@ -69,6 +85,9 @@
             "browserTarget": "frontend-lib:build"
           },
           "configurations": {
+            "staging": {
+              "browserTarget": "frontend-lib:build:staging"
+            },
             "production": {
               "browserTarget": "frontend-lib:build:production"
             }
@@ -118,6 +137,9 @@
             "devServerTarget": "frontend-lib:serve"
           },
           "configurations": {
+            "staging": {
+              "devServerTarget": "frontend-lib:serve:staging"
+            },
             "production": {
               "devServerTarget": "frontend-lib:serve:production"
             }

--- a/build-script.js
+++ b/build-script.js
@@ -10,9 +10,9 @@ const concat = require('concat');
   ]
 
   await fs.ensureDir('elements')
-
   await concat(files, 'elements/frontend-lib.js')
+  await fs.copyFile('./dist/frontend-lib/styles.css', 'elements/styles.css')
+  await fs.copyFile('./dist/frontend-lib/data-table.woff', 'elements/data-table.woff')
   console.info('Frontend-lib Elements created successfully!')
 
 })()
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -12051,6 +12051,11 @@
         }
       }
     },
+    "subsink": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/subsink/-/subsink-1.0.2.tgz",
+      "integrity": "sha512-QFL2oKaA6jVai82dcF0/SIKHNrKJO/wAiHBw9CG576+eBzeg+lZmpG63Tvajx3yg05Hf9ZIZ+zroJutj3hvLNQ=="
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "build:elements:staging": "ng build --configuration=staging --output-hashing none && node build-script.js",
-    "build:elements:production": "ng build --configuration=production --output-hashing none && node build-script.js"
+    "build:dts": "ng build --configuration=production --output-hashing none && node build-script.js"
   },
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "build:elements": "ng build --prod --output-hashing none && node build-script.js"
+    "build:elements:staging": "ng build --configuration=staging --output-hashing none && node build-script.js",
+    "build:elements:production": "ng build --configuration=production --output-hashing none && node build-script.js"
   },
   "private": true,
   "dependencies": {
@@ -27,6 +28,7 @@
     "@webcomponents/custom-elements": "^1.4.2",
     "ckeditor4-angular": "^2.0.0",
     "rxjs": "~6.6.0",
+    "subsink": "^1.0.2",
     "tslib": "^2.0.0",
     "zone.js": "~0.10.2"
   },

--- a/src/app/dts/dts.service.ts
+++ b/src/app/dts/dts.service.ts
@@ -11,7 +11,7 @@ import {Template} from './template.types';
 export class DtsService {
 
   /**
-   * URL to the DTS Service.  TODO: Currently using a local instance of the service as the service is in development and not live.
+   * URL to the DTS Service.
    */
   url = environment.dtsUrl;
 
@@ -25,7 +25,9 @@ export class DtsService {
    * Retrieves and indication is the backend DTS service is healthy.
    */
   public getStatus(): Observable<string> {
-    return this.http.get(this.url + 'status', {responseType: 'text'});
+    return this.http.get(this.url + 'status', {responseType: 'text'}).pipe(catchError( error => {
+      return throwError(error);
+    }));
   }
 
   /**

--- a/src/app/dts/unsubscribe-on-destroy-adapter.ts
+++ b/src/app/dts/unsubscribe-on-destroy-adapter.ts
@@ -1,0 +1,22 @@
+import {Component, Directive, OnDestroy} from '@angular/core';
+import {SubSink} from 'subsink';
+import {Subject} from 'rxjs';
+
+/**
+ * A class that automatically unsubscribes all observables when the object gets destroyed
+ */
+@Component({template: ''})
+export class UnsubscribeOnDestroyAdapter implements OnDestroy {
+  /** The subscription sink object that stores all subscriptions */
+  protected subs = new SubSink();
+  /** Subject that emits a value on destroy to unsubscribe all subscriptions that use a "takeUntil" approach */
+  protected destroy = new Subject();
+
+  /**
+   * The lifecycle hook that unsubscribes all subscriptions when the component / object gets destroyed
+   */
+  ngOnDestroy(): void {
+    this.destroy.next();
+    this.subs.unsubscribe();
+  }
+}

--- a/src/app/dts/unsubscribe-on-destroy-adapter.ts
+++ b/src/app/dts/unsubscribe-on-destroy-adapter.ts
@@ -6,6 +6,7 @@ import {Subject} from 'rxjs';
  * A class that automatically unsubscribes all observables when the object gets destroyed
  */
 @Component({template: ''})
+// tslint:disable-next-line:component-class-suffix
 export class UnsubscribeOnDestroyAdapter implements OnDestroy {
   /** The subscription sink object that stores all subscriptions */
   protected subs = new SubSink();

--- a/src/environments/environment.stage.ts
+++ b/src/environments/environment.stage.ts
@@ -1,4 +1,0 @@
-export const environment = {
-  production: false,
-  dtsUrl: 'http://dts-staging.us-west-2.elasticbeanstalk.com/'
-};

--- a/src/environments/environment.stage.ts
+++ b/src/environments/environment.stage.ts
@@ -1,5 +1,4 @@
 export const environment = {
-  production: true,
-  // todo - point to production endpoint
+  production: false,
   dtsUrl: 'http://dts-staging.us-west-2.elasticbeanstalk.com/'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,7 +1,5 @@
-
 export const environment = {
   production: false,
-  // TODO: Currently the dts server is not live - update once the dts server is in production and live
   dtsUrl: 'http://localhost:8080/'
 };
 


### PR DESCRIPTION
This update creates the necessary files to run the DTS component from an external application (i.e. CEMS).

The build output will be used when deploying the output to CEMS.  See https://homeceu.atlassian.net/browse/CEMS-2077.

Additional changes:
- Creates staging and production environment files
- Reduces typeahead lookup timeout for filtering from 1 second to 0.5 seconds.
- Adds debug/error handling when unable to connect to the DTS backend.
- Use sublink to unsubscribes observables.

Note: had to use "@Component({template: ''})" in UnsubscribeOnDestroyAdapter due to an Angular 10 change.