### PR TITLE
Frontend dts regression testing scenarios CEMS-2196

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Regression tests make use of [Cucumber with Cypress](https://www.npmjs.com/packa
 - `npm run test:cypress:ci` to run regression tests locally -  starts the application, waits for the URL, then runs regression tests; when the tests end, shuts down app
 - `npm run test:cypress:run` to run regression tests locally against the currently running application
 
-Regression test follow Behavioral Driven Development (BDD) and apply the following best practices:
+Regression tests follow Behavioral Driven Development (BDD) and apply the following best practices:
 - Tests are contained in “feature” files.
 - Feature files contain a title, a single User Story, and one or more scenarios to test the User Story.
   - The title communicate in one concise line what the behavior is.

--- a/README.md
+++ b/README.md
@@ -17,14 +17,27 @@ Run `ng generate component component-name` to generate a new component. You can 
 
 ## Running unit tests
 
-Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.io).
+Developing and running `ng test` to execute the unit tests via [Karma](https://karma-runner.github.io).
 
-## Running end-to-end tests
+## Developing and running end-to-end tests
 
-Regession tests make use of [Cucumber with Cypress](https://www.npmjs.com/package/cypress-cucumber-preprocessor).
+Regression tests make use of [Cucumber with Cypress](https://www.npmjs.com/package/cypress-cucumber-preprocessor).
 
 - `npm run test:cypress:ci` to run regression tests locally -  starts the application, waits for the URL, then runs regression tests; when the tests end, shuts down app
 - `npm run test:cypress:run` to run regression tests locally against the currently running application
+
+Regression test follow Behavioral Driven Development (BDD) and apply the following best practices:
+- Tests are contained in “feature” files.
+- Feature files contain a title, a single User Story, and one or more scenarios to test the User Story.
+  - The title communicate in one concise line what the behavior is.
+  - The User Story is written in the format “As a <type of user> I want <goal> so that <reason>.”
+  - Scenarios are written in the Gherkin syntax and optionally contain “Examples” to test multiple outcomes.
+
+Gherkin best practices
+- A good scenario has only one When-Then pair.
+- Given steps should use past or present-perfect tense, because they represent an initial state that must already be established.
+- When steps should use present tense, because they represent actions actively performed as part of the behavior.
+- Then steps should use present or future tense, because they represent what should happen after the behavior actions.
 
 ## Further help
 

--- a/cypress/fixtures/templates.js
+++ b/cypress/fixtures/templates.js
@@ -1,0 +1,54 @@
+export const TemplateAdminApproved = `<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=EmulateIE8"/>
+    <style>
+        {{> standard_certificate_style}}
+    </style>
+</head>
+
+<body>
+<div id="container" class="page">
+
+    <p class="header_images">
+        {{> homeceu_logo.png }}
+    </p>
+
+    <p style="text-align:center;">
+        Enrollment #: <span class="char-style-override-6">{{ enrollmentId }}</span>
+    </p>
+
+    <p>
+        <span class="char-style-override-3">This is to acknowledge that </span>
+        <span class="char-style-override-1">{{> student_name}}</span>
+    </p>
+
+    <p>
+        <span class="char-style-override-3">Has completed </span>
+        <span class="char-style-override-1">{{ course.name }}</span>
+    </p>
+
+    <p class="char-style-override-3">
+        a {{ course.hours }} hour development and/or training program
+    </p>
+    <p>
+        <span class="char-style-override-3"> via </span>
+        <span class="char-style-override-1">{{ completion_method }}</span>
+    </p>
+
+    <p>
+        <span class="char-style-override-3"> on </span>
+        <span class="char-style-override-1">{{ completionDate }}</span>
+    </p>
+
+    <p>
+        {{ supervisor.first_name }} {{ supervisor.last_name }} has indicated completion for this user.
+    </p>
+
+    <p>
+        The awarding of this certificate does not award continuing education hours / credit.
+    </p>
+</div>
+</body>
+</html>
+`;

--- a/cypress/integration/Template_Copy.feature
+++ b/cypress/integration/Template_Copy.feature
@@ -4,7 +4,7 @@ Feature: Copy an existing template
   new template and to use styles and data from an existing template
 
   Scenario: Copy an existing template
-    Given A form displayed to manage a template
+    Given A form displayed to manage template "admin-approved"
     When I request to copy the template
     Then The existing template is copied to a new template
 

--- a/cypress/integration/Template_Copy.feature
+++ b/cypress/integration/Template_Copy.feature
@@ -1,0 +1,10 @@
+Feature: Copy an existing template
+
+  As a system administrator I want to copy an existing template so that I can reduce the time needed to create a
+  new template and to use styles and data from an existing template
+
+  Scenario: Copy an existing template
+    Given A form displayed to manage a template
+    When I request to copy the template
+    Then The existing template is copied to a new template
+

--- a/cypress/integration/Template_Create.feature
+++ b/cypress/integration/Template_Create.feature
@@ -1,0 +1,9 @@
+Feature: Create a new template
+
+  As a system administrator I want to create a new template so that the template can be used to create a
+  certificate.
+
+  Scenario: Display a form to create a new template
+    Given A list of templates
+    When I request to create a new template
+    Then A form is displayed to manage the template

--- a/cypress/integration/Template_Create.feature
+++ b/cypress/integration/Template_Create.feature
@@ -6,4 +6,23 @@ Feature: Create a new template
   Scenario: Display a form to create a new template
     Given A list of templates
     When I request to create a new template
-    Then A form is displayed to manage the template
+    Then A form is displayed to create the template
+
+  Scenario Outline: Create A template
+    Given A template editor is displayed to create a template
+    When I enter "<template_text>" into the editor
+    And I request to change the view mode
+    And I request to change the view mode
+    Then The editor contains additional markup for "<template_text>"
+
+    Examples:
+      | template_text                                |
+      | Simple template                              |
+      | This is a new template which contains data   |
+
+  Scenario: Save a new template (draft)
+    Given A template editor is displayed to create a template
+    When I enter "My Template" into the editor
+    #And I enter a template name "Test Template"
+    #And I request to save the template
+    #Then The template is saved

--- a/cypress/integration/Template_Details.feature
+++ b/cypress/integration/Template_Details.feature
@@ -1,6 +1,7 @@
-Feature: View existing template details
+Feature: View details of an existing template
 
-  I want to display details of a template so that I can find out information about existing templates in the system.
+  As a system administrator I want to display details of an existing template so that I can view
+  additional properties of the template.
 
   Scenario Outline: View template details
     Given A list of templates

--- a/cypress/integration/Template_Edit.feature
+++ b/cypress/integration/Template_Edit.feature
@@ -9,18 +9,22 @@ Feature: Manage existing template
     Then A form is displayed to manage the template
 
   Scenario: Close editor without changes
-    Given A form displayed to manage a template
+    Given A form displayed to manage template "admin-approved"
     When I request to close the form
     Then The template editor form is closed
 
   Scenario: Preview a template
-    Given A form displayed to manage a template
+    Given A form displayed to manage template "admin-approved"
     When I request to change the view mode
     Then The template is rendered in WYSISYG mode
 
-  Scenario: Edit and save template (draft)
-    Given A form displayed to manage a template
-    #When I request to change the view mode
-    #And I enter "additonal text" into the editor
+  Scenario Outline: Edit and save template
+    Given A form displayed to manage template "benchmark"
+    When I replace the text "<current_text>" with the new "<new_text>"
     #And I request to save the template
-    #Then The template is saved
+    Then The template is saved
+    And The template contains the text "<new_text>"
+
+    Examples:
+      | current_text    | new_text      |
+      | test            | updated text  |

--- a/cypress/integration/Template_Edit.feature
+++ b/cypress/integration/Template_Edit.feature
@@ -1,0 +1,26 @@
+Feature: Manage existing template
+
+  As a system administrator I want to view and edit an existing templates so that I can manage my existing my
+  exiting templates.
+
+  Scenario: Display an existing template
+    Given A list of templates
+    When I request to view an existing template
+    Then A form is displayed to manage the template
+
+  Scenario: Close editor without changes
+    Given A form displayed to manage a template
+    When I request to close the form
+    Then The template editor form is closed
+
+  Scenario: Preview a template
+    Given A form displayed to manage a template
+    When I request to change the view mode
+    Then The template is rendered in WYSISYG mode
+
+  Scenario: Edit and save template (draft)
+    Given A form displayed to manage a template
+    #When I request to change the view mode
+    #And I enter "additonal text" into the editor
+    #And I request to save the template
+    #Then The template is saved

--- a/cypress/integration/Template_Grid_Paging.feature
+++ b/cypress/integration/Template_Grid_Paging.feature
@@ -1,0 +1,29 @@
+Feature: Navigate though a list of existing templates
+
+  As a system administrator I want to navigate though a list of existing templates
+  so that I can identify existing templates.
+
+  Background:
+    Given A list of templates
+
+  Scenario: Navigate to the last page
+    When I navigate to the last page
+    Then The last page is displayed
+
+  Scenario: Navigate to the first page
+    When I navigate to the last page
+    And I navigate to the first page
+    Then The first page is displayed
+
+  Scenario: Navigate to the next page
+    When I navigate to the next page
+    Then The next page is displayed
+
+  Scenario: Navigate to the previous page
+    When I navigate to the next page
+    And I navigate to the previous page
+    Then The previous page is displayed
+
+  Scenario: Navigate to a specific page number
+    When I navigate to page two
+    Then Page two is displayed

--- a/cypress/integration/Template_Grid_Search.feature
+++ b/cypress/integration/Template_Grid_Search.feature
@@ -1,0 +1,33 @@
+Feature: Search list of existing templates
+
+  As a system administrator I want to search for a template so that I can identify existing templates.
+
+  Scenario Outline: Search for a template by the Template Name
+    Given A list of templates
+    When I search for templates containing "<search_value>"
+    Then "<num_of_templates>" templates are displayed for template "<search_value>"
+
+    Examples:
+      | search_value    | num_of_templates |
+      | badvalue        | 0                |
+      | in              | 4                |
+      | encompass_care  | 1                |
+      | admin-approved  | 1                |
+      | infinity_rehab  | 1                |
+
+  Scenario Outline: Search for a template by the Author
+    Given A list of templates
+    When I search for templates containing "<search_value>"
+    Then "<num_of_templates>" templates are displayed for author "<search_value>"
+
+    Examples:
+      | search_value    | num_of_templates |
+      | badvalue        | 0                |
+      | Dan             | 13               |
+
+  Scenario: Clearing search field displays original list of templates
+    Given Search results for "encompass_care" are shown
+    When I clear the search field
+    Then An unfiltered list of templates is displayed
+
+

--- a/cypress/integration/Template_Grid_Search.feature
+++ b/cypress/integration/Template_Grid_Search.feature
@@ -23,7 +23,8 @@ Feature: Search list of existing templates
     Examples:
       | search_value    | num_of_templates |
       | badvalue        | 0                |
-      | Dan             | 13               |
+      | Dan             | 12               |
+      | Test User       | 3                |
 
   Scenario: Clearing search field displays original list of templates
     Given Search results for "encompass_care" are shown

--- a/cypress/integration/Template_Grid_Sort.feature
+++ b/cypress/integration/Template_Grid_Sort.feature
@@ -13,6 +13,6 @@ Feature: Sort list of existing templates
     When I sort by author
     Then A list of templates are displayed sorted by author, descending
 
-  Scenario: Sort templates by date and time
-    When I sort by date and time
-    Then A list of templates are displayed sorted by date and time, descending
+#  Scenario: Sort templates by date and time
+#    When I sort by date and time
+#    Then A list of templates are displayed sorted by date and time, descending

--- a/cypress/integration/Template_Grid_Sort.feature
+++ b/cypress/integration/Template_Grid_Sort.feature
@@ -1,0 +1,18 @@
+Feature: Sort list of existing templates
+
+  As a system administrator I want to sort a list of templates so that I can identify existing templates.
+
+  Background:
+    Given A list of templates
+
+  Scenario: Sort templates by template name
+    When I sort by template name
+    Then A list of templates are displayed sorted by template name, descending
+
+  Scenario: Sort templates by author
+    When I sort by author
+    Then A list of templates are displayed sorted by author, descending
+
+  Scenario: Sort templates by date and time
+    When I sort by date and time
+    Then A list of templates are displayed sorted by date and time, descending

--- a/cypress/integration/Template_View.feature
+++ b/cypress/integration/Template_View.feature
@@ -1,0 +1,8 @@
+Feature: View an existing template
+
+  As a system administrator I want to view an existing template so that I can view template and certificate details.
+
+  Scenario: Display an existing template
+    Given A list of templates
+    When I request to view an existing template
+    Then A form is displayed to manage the template

--- a/cypress/integration/Template_View.feature
+++ b/cypress/integration/Template_View.feature
@@ -1,8 +1,0 @@
-Feature: View an existing template
-
-  As a system administrator I want to view an existing template so that I can view template and certificate details.
-
-  Scenario: Display an existing template
-    Given A list of templates
-    When I request to view an existing template
-    Then A form is displayed to manage the template

--- a/cypress/integration/common/step_definitions/TemplateCrud.js
+++ b/cypress/integration/common/step_definitions/TemplateCrud.js
@@ -2,9 +2,9 @@ import {TemplateAdminApproved} from "../../../fixtures/templates";
 import {getTemplates, searchTemplates} from "../../../page-objects/template.po";
 import {Given} from "cypress-cucumber-preprocessor/steps";
 
-Given('A form displayed to manage a template', () => {
+Given('A form displayed to manage template {string}', (template_name) => {
   getTemplates();
-  searchTemplates('admin-approved');
+  searchTemplates(template_name);
   cy.get(`:nth-child(1) > .datatable-body-row`).click();
 })
 
@@ -54,6 +54,10 @@ When('I enter a template name {string}', (template_key) => {
   cy.get('input[formcontrolname*="templateKey"]').type(template_key)
 })
 
+When('I replace the text {string} with the new {string}', (current_text, new_text) => {
+  // todo
+})
+
 Then('A form is displayed to manage the template', () => {
   cy.get('.mat-dialog-container').should('exist');
   cy.get('.cke_source').should('have.value', TemplateAdminApproved);
@@ -87,5 +91,9 @@ Then('The editor contains additional markup for {string}', (template_text) => {
 })
 
 Then('The template is saved', () => {
+  // todo
+})
+
+Then('The template contains the text {string}', (template_text) => {
   // todo
 })

--- a/cypress/integration/common/step_definitions/TemplateCrud.js
+++ b/cypress/integration/common/step_definitions/TemplateCrud.js
@@ -1,0 +1,16 @@
+import {dataTableHeader} from "../../../page-objects/template.po";
+
+When('I request to view an existing template', () => {
+  cy.get('input').type('admin-approved')
+  cy.get(
+    `:nth-child(1) > .datatable-body-row`).click();
+})
+
+When('I request to create a new template', () => {
+  cy.get('#create').click()
+})
+
+Then('A form is displayed to manage the template', () => {
+  cy.get('.mat-dialog-container').should('exist');
+})
+

--- a/cypress/integration/common/step_definitions/TemplateCrud.js
+++ b/cypress/integration/common/step_definitions/TemplateCrud.js
@@ -1,16 +1,91 @@
-import {dataTableHeader} from "../../../page-objects/template.po";
+import {TemplateAdminApproved} from "../../../fixtures/templates";
+import {getTemplates, searchTemplates} from "../../../page-objects/template.po";
+import {Given} from "cypress-cucumber-preprocessor/steps";
+
+Given('A form displayed to manage a template', () => {
+  getTemplates();
+  searchTemplates('admin-approved');
+  cy.get(`:nth-child(1) > .datatable-body-row`).click();
+})
+
+Given('A template editor is displayed to create a template', () => {
+  getTemplates();
+  cy.get('#create').click()
+})
+
+// Given('The editor is displayed in WYSIWYG mode', () => {
+//   cy.get('.cke_button__source').click()
+// })
+
+// Given('I made changes to the template', () => {
+//   cy.get('.cke_source').type('** EDITED TEMPLATE **')
+// })
 
 When('I request to view an existing template', () => {
-  cy.get('input').type('admin-approved')
-  cy.get(
-    `:nth-child(1) > .datatable-body-row`).click();
+  searchTemplates('admin-approved');
+  cy.get(`:nth-child(1) > .datatable-body-row`).click();
 })
 
 When('I request to create a new template', () => {
   cy.get('#create').click()
 })
 
-Then('A form is displayed to manage the template', () => {
-  cy.get('.mat-dialog-container').should('exist');
+When('I request to copy the template', () => {
+  cy.get('#copy').click()
 })
 
+When('I request to close the form', () => {
+  cy.get('#close').click()
+})
+
+When('I request to save the template', () => {
+  cy.get('#save').click()
+})
+
+When('I request to change the view mode', () => {
+  cy.get('.cke_button__source').click()
+})
+
+When('I enter {string} into the editor', (template_text) => {
+  cy.get('.cke_source').type(template_text)
+})
+
+When('I enter a template name {string}', (template_key) => {
+  cy.get('input[formcontrolname*="templateKey"]').type(template_key)
+})
+
+Then('A form is displayed to manage the template', () => {
+  cy.get('.mat-dialog-container').should('exist');
+  cy.get('.cke_source').should('have.value', TemplateAdminApproved);
+  cy.get('#save').should('have.class', 'mat-button-disabled');
+  cy.get('#copy').should('not.have.class', 'mat-button-disabled');
+})
+
+Then('A form is displayed to create the template', () => {
+  cy.get('.mat-dialog-container').should('exist');
+  cy.get('.cke_source').should('have.value', '');
+  cy.get('#save').should('have.class', 'mat-button-disabled');
+  cy.get('#copy').should('have.class', 'mat-button-disabled');
+})
+
+Then('The existing template is copied to a new template', () => {
+  cy.get('#copy').should('have.class', 'mat-button-disabled');
+  // todo - may need to find a way to verify the contents of the editor were not changed
+})
+
+Then('The template editor form is closed', () => {
+  cy.get('.mat-dialog-container').should('not.exist');
+})
+
+Then('The template is rendered in WYSISYG mode', (template_id) => {
+  cy.get('iframe').should('exist');
+})
+
+Then('The editor contains additional markup for {string}', (template_text) => {
+  let templateDisplayed = `<html>\n<head>\n\t<title></title>\n</head>\n<body>\n<p>${template_text}</p>\n</body>\n</html>\n`
+  cy.get('.cke_source').should('have.value', templateDisplayed);
+})
+
+Then('The template is saved', () => {
+  // todo
+})

--- a/cypress/integration/common/step_definitions/TemplateGrid.js
+++ b/cypress/integration/common/step_definitions/TemplateGrid.js
@@ -1,4 +1,8 @@
 import { Given } from "cypress-cucumber-preprocessor/steps";
+import {
+  dataTableExpandRow,
+  dataTableTemplateDetails
+} from "../../../page-objects/template.po";
 
 const url = 'http://localhost:4200/'
 
@@ -9,19 +13,17 @@ Given('A list of templates', () => {
 })
 
 When('I expand row {string} for a template', (row_number) => {
-  cy.get(
-    ':nth-child(' + row_number + ') > .datatable-body-row > .datatable-row-center > :nth-child(1) > .datatable-body-cell-label > a'
-  ).click()
+  dataTableExpandRow(row_number).click()
 })
 
 Then('Template details should contain a Template ID {string}', (template_id) => {
-  cy.get('table>tr').eq(0).contains('td', template_id);
+  dataTableTemplateDetails(0).contains('td', template_id);
 })
 
 Then('template details should contain a Body Uri {string}', (template_id) => {
-  cy.get('table>tr').eq(1).contains('td', template_id);
+  dataTableTemplateDetails(1).contains('td', template_id);
 })
 
 Then('template details should contain a Document Type {string}', (template_id) => {
-  cy.get('table>tr').eq(2).contains('td', template_id);
+  dataTableTemplateDetails(2).contains('td', template_id);
 })

--- a/cypress/integration/common/step_definitions/TemplateGrid.js
+++ b/cypress/integration/common/step_definitions/TemplateGrid.js
@@ -1,15 +1,13 @@
 import { Given } from "cypress-cucumber-preprocessor/steps";
 import {
   dataTableExpandRow,
-  dataTableTemplateDetails
+  dataTableTemplateDetails, getTemplates
 } from "../../../page-objects/template.po";
 
 const url = 'http://localhost:4200/'
 
 Given('A list of templates', () => {
-  cy.intercept('GET', '**/template*').as('getTemplates')
-  cy.visit(url)
-  cy.wait('@getTemplates');
+  getTemplates();
 })
 
 When('I expand row {string} for a template', (row_number) => {

--- a/cypress/integration/common/step_definitions/TemplatePaging.js
+++ b/cypress/integration/common/step_definitions/TemplatePaging.js
@@ -1,0 +1,48 @@
+import {
+  dataTableFirstPage,
+  dataTableLastPage,
+  dataTableNextPage,
+  dataTablePreviousPage
+} from "../../../page-objects/template.po";
+
+When('I navigate to the last page', () => {
+  cy.get('ul.pager>li').eq(dataTableLastPage).click()
+})
+
+When('I navigate to the first page', () => {
+  cy.get('ul.pager>li').eq(dataTableFirstPage).click()
+})
+
+When('I navigate to the next page', () => {
+  cy.get('ul.pager>li').eq(dataTableNextPage).click()
+})
+
+When('I navigate to the previous page', () => {
+  cy.get('ul.pager>li').eq(dataTablePreviousPage).click()
+})
+
+When('I navigate to page two', () => {
+  cy.get('ul.pager>li').eq(3).click()
+})
+
+Then('The last page is displayed', () => {
+  cy.get('ul.pager>li').eq(dataTableLastPage).should('have.class', 'disabled')
+  cy.get('ul.pager>li').eq(dataTableFirstPage).should('not.have.class', 'disabled')
+})
+
+Then('The first page is displayed', () => {
+  cy.get('ul.pager>li').eq(dataTableLastPage).should('not.have.class', 'disabled')
+  cy.get('ul.pager>li').eq(dataTableFirstPage).should('have.class', 'disabled')
+})
+
+Then('The next page is displayed', () => {
+  cy.get('ul.pager>li').eq(dataTableFirstPage).should('not.have.class', 'disabled')
+})
+
+Then('The previous page is displayed', () => {
+  cy.get('ul.pager>li').eq(dataTableFirstPage).should('have.class', 'disabled')
+})
+
+Then('Page two is displayed', () => {
+  cy.get('ul.pager>li').eq(3).should('have.class', 'active')
+})

--- a/cypress/integration/common/step_definitions/TemplatePreview.js
+++ b/cypress/integration/common/step_definitions/TemplatePreview.js
@@ -1,0 +1,9 @@
+import {dataTableTemplateDetails} from "../../../page-objects/template.po";
+
+When('I request to change the view mode', () => {
+  cy.get('.cke_button__source').click()
+})
+
+Then('The template is rendered in WYSISYG mode', (template_id) => {
+  cy.get('iframe').should('exist');
+})

--- a/cypress/integration/common/step_definitions/TemplateSearch.js
+++ b/cypress/integration/common/step_definitions/TemplateSearch.js
@@ -1,22 +1,19 @@
 import {Given} from "cypress-cucumber-preprocessor/steps";
 import {
   dataTableTemplateName,
-  dataTableAuthor
+  dataTableAuthor, searchTemplates, getTemplates
 } from "../../../page-objects/template.po";
-
-const url = 'http://localhost:4200/'
 
 const ITEMS_IN_PAGE = 10;
 
 Given(`Search results for {string} are shown`, (search_value) => {
-  cy.intercept('GET', '**/template*').as('getTemplates')
-  cy.visit(url)
-  cy.wait('@getTemplates');
-  cy.get('input').type(search_value)
+  getTemplates();
+
+  searchTemplates(search_value);
 })
 
 When('I search for templates containing {string}', (search_value) => {
-  cy.get('input').type(search_value)
+  searchTemplates(search_value);
 })
 
 When('I clear the search field', () => {
@@ -44,5 +41,5 @@ Then('{string} templates are displayed for author {string}', (num_of_templates, 
 })
 
 Then('An unfiltered list of templates is displayed', () => {
-  cy.get(".page-count").should("contain", "13");
+  cy.get(".page-count").should("contain", "15");
 })

--- a/cypress/integration/common/step_definitions/TemplateSearch.js
+++ b/cypress/integration/common/step_definitions/TemplateSearch.js
@@ -1,0 +1,48 @@
+import {Given} from "cypress-cucumber-preprocessor/steps";
+import {
+  dataTableTemplateName,
+  dataTableAuthor
+} from "../../../page-objects/template.po";
+
+const url = 'http://localhost:4200/'
+
+const ITEMS_IN_PAGE = 10;
+
+Given(`Search results for {string} are shown`, (search_value) => {
+  cy.intercept('GET', '**/template*').as('getTemplates')
+  cy.visit(url)
+  cy.wait('@getTemplates');
+  cy.get('input').type(search_value)
+})
+
+When('I search for templates containing {string}', (search_value) => {
+  cy.get('input').type(search_value)
+})
+
+When('I clear the search field', () => {
+  cy.get('#clear').click()
+})
+
+Then('{string} templates are displayed for template {string}', (num_of_templates, search_value) => {
+  // verify the displayed items contain the search field
+  const templates = num_of_templates > ITEMS_IN_PAGE ? ITEMS_IN_PAGE : num_of_templates;
+  for(let i = 1; i < templates; i++) {
+    dataTableTemplateName(i).should('contain', search_value);
+  }
+
+  cy.get(".page-count").should("contain", num_of_templates);
+})
+
+Then('{string} templates are displayed for author {string}', (num_of_templates, search_value) => {
+  // verify the displayed items contain the search field
+  const templates = num_of_templates > ITEMS_IN_PAGE ? ITEMS_IN_PAGE : num_of_templates;
+  for(let i = 1; i < templates; i++) {
+    dataTableAuthor(i).should('contain', search_value);
+  }
+
+  cy.get(".page-count").should("contain", num_of_templates);
+})
+
+Then('An unfiltered list of templates is displayed', () => {
+  cy.get(".page-count").should("contain", "13");
+})

--- a/cypress/integration/common/step_definitions/TemplateSort.js
+++ b/cypress/integration/common/step_definitions/TemplateSort.js
@@ -1,0 +1,30 @@
+import {
+  dataTableHeader,
+  dataTableTemplateName,
+  dataTableAuthor,
+  dataTableDateTime
+} from "../../../page-objects/template.po";
+
+When('I sort by template name', () => {
+  dataTableHeader(2).click();
+})
+
+When('I sort by author', () => {
+  dataTableHeader(3).click();
+})
+
+When('I sort by date and time', () => {
+  dataTableHeader(4).click();
+})
+
+Then('A list of templates are displayed sorted by template name, descending', () => {
+  dataTableTemplateName(1).should('contain', 'vibrant-care');
+})
+
+Then('A list of templates are displayed sorted by author, descending', () => {
+  dataTableAuthor(1).should('contain', 'Dan');
+})
+
+Then('A list of templates are displayed sorted by date and time, descending', () => {
+  dataTableDateTime(1).should('contain', '3/23/20, 11:40 AM');
+})

--- a/cypress/page-objects/template.po.js
+++ b/cypress/page-objects/template.po.js
@@ -1,0 +1,32 @@
+export const dataTableFirstPage = 0;
+export const dataTablePreviousPage = 1;
+export const dataTableNextPage = 4;
+export const dataTableLastPage = 5;
+
+export const dataTableHeader = colNumber =>
+  cy.get(
+    `:nth-child(${colNumber}) > .datatable-header-cell-template-wrap > .datatable-header-cell-wrapper > .datatable-header-cell-label`
+  );
+
+export const dataTableTemplateName = rowNumber =>
+  cy.get(
+    `:nth-child(${rowNumber}) > .datatable-body-row > .datatable-row-center > :nth-child(2) > .datatable-body-cell-label > span`
+  );
+
+export const dataTableAuthor = rowNumber =>
+  cy.get(
+    `:nth-child(${rowNumber}) > .datatable-body-row > .datatable-row-center > :nth-child(3) > .datatable-body-cell-label > span`
+  );
+
+export const dataTableDateTime = rowNumber =>
+  cy.get(
+    `:nth-child(${rowNumber}) > .datatable-body-row > .datatable-row-center > :nth-child(4) > .datatable-body-cell-label`
+  );
+
+export const dataTableTemplateDetails = id =>
+  cy.get('.datatable-row-detail > table > tr').eq(id);
+
+export const dataTableExpandRow = rowNumber =>
+  cy.get(
+    `:nth-child(${rowNumber}) > .datatable-body-row > .datatable-row-center > :nth-child(1) > .datatable-body-cell-label > a`
+  );

--- a/cypress/page-objects/template.po.js
+++ b/cypress/page-objects/template.po.js
@@ -3,6 +3,8 @@ export const dataTablePreviousPage = 1;
 export const dataTableNextPage = 4;
 export const dataTableLastPage = 5;
 
+const url = 'http://localhost:4200/'
+
 export const dataTableHeader = colNumber =>
   cy.get(
     `:nth-child(${colNumber}) > .datatable-header-cell-template-wrap > .datatable-header-cell-wrapper > .datatable-header-cell-label`
@@ -30,3 +32,16 @@ export const dataTableExpandRow = rowNumber =>
   cy.get(
     `:nth-child(${rowNumber}) > .datatable-body-row > .datatable-row-center > :nth-child(1) > .datatable-body-cell-label > a`
   );
+
+export function getTemplates() {
+  cy.viewport(1400, 1000);
+  cy.intercept('GET', '**/template*').as('getTemplates');
+  cy.visit(url);
+  cy.wait('@getTemplates');
+}
+
+export function searchTemplates(searchValue) {
+  cy.intercept('GET', '**/template*').as('getTemplates')
+  cy.get('input').type(searchValue)
+  cy.wait('@getTemplates');
+}

--- a/src/app/dts/dts.component.html
+++ b/src/app/dts/dts.component.html
@@ -1,10 +1,10 @@
 <form [formGroup]="dtsForm">
-  <button type="button" (click)="newTemplate()" mat-button>
+  <button id="create" type="button" (click)="newTemplate()" mat-button>
     <b>&#43;</b>
   </button>
   <mat-form-field class="filterby-form-field">
     <input class="filterBy" matInput type="text" formControlName="templateFilter" placeholder="Type to filter by key or author...">
-    <button mat-button *ngIf="dtsForm.value.templateFilter" matSuffix mat-icon-button aria-label="Clear" (click)="dtsForm.reset()">
+    <button id="clear" mat-button *ngIf="dtsForm.value.templateFilter" matSuffix mat-icon-button aria-label="Clear" (click)="dtsForm.reset()">
       &#120;
     </button>
   </mat-form-field>

--- a/src/app/dts/dts.component.ts
+++ b/src/app/dts/dts.component.ts
@@ -64,7 +64,7 @@ export class DtsComponent extends UnsubscribeOnDestroyAdapter implements OnInit 
         console.log(`User: ${this.userName}  Status: ${status}  Endpoint: ${this.dtsService.url}`);
       },
       error => {
-        console.log(`Failed to connect to ${this.dtsService.url} - ${error.message}`);
+        console.error(`Failed to connect to ${this.dtsService.url} - ${error.message}`);
       });
 
     this.rows = this.dtsService.getTemplates('enrollment');

--- a/src/app/dts/template-editor/template-editor.component.html
+++ b/src/app/dts/template-editor/template-editor.component.html
@@ -15,10 +15,10 @@
     </div>
   </div>
   <div class="flex-row">
-    <button type="button" (click)="copyTemplate()" [disabled]="canCopy()" mat-button>
+    <button id="copy" type="button" (click)="copyTemplate()" [disabled]="canCopy()" mat-button>
       Copy
     </button>
-    <button type="button" (click)="discardChangesAndClose()" mat-button>
+    <button id="close" type="button" (click)="discardChangesAndClose()" mat-button>
       Close
     </button>
     <div class="statusMessage">
@@ -32,7 +32,7 @@
         {{ statusMessage }}
       </span>
     </div>
-    <button id="saveButton" type="submit" [disabled]="!canSave()" mat-button>
+    <button id="save" type="submit" [disabled]="!canSave()" mat-button>
       Save
     </button>
     <button type="button" (click)="toggleDataFields()" class="push" mat-button>

--- a/src/app/dts/template-editor/template-editor.component.ts
+++ b/src/app/dts/template-editor/template-editor.component.ts
@@ -21,6 +21,8 @@ declare var CKEDITOR: any;
   styleUrls: ['./template-editor.component.scss']
 })
 export class TemplateEditorComponent extends UnsubscribeOnDestroyAdapter implements OnInit, OnDestroy {
+  // todo - need to fix a save bug which requires the user to cycle between modes before saving
+
   /**
    * Either creating or editing a template used to prevent changing the Template Name for an existing template
    */
@@ -79,9 +81,9 @@ export class TemplateEditorComponent extends UnsubscribeOnDestroyAdapter impleme
     // configure the template editor
     this.configTemplateEditor();
 
-    if (this.templateObject.docType && this.templateObject.templateKey) {
-      this.templateEditor.patchValue(this.templateObject);
+    this.templateEditor.patchValue(this.templateObject);
 
+    if (this.templateObject.docType && this.templateObject.templateKey) {
       // retrieve template content for existing template
       this.subs.sink = this.dtsService.getTemplateByKey(this.templateObject.docType, this.templateObject.templateKey).subscribe(data => {
         CKEDITOR.instances.editor1.setData(data, () => {
@@ -215,7 +217,8 @@ export class TemplateEditorComponent extends UnsubscribeOnDestroyAdapter impleme
         this.existingTemplate = true;
         this.statusMessage = 'Template saved';
       },
-      () => {
+      (error) => {
+        console.log(`Save failed: $(error)`);
         this.templateEditor.setErrors({ saveFailed: true });
       });
   }


### PR DESCRIPTION
This update creates frontend regression tests for dts:
- Paging, sorting and filtering templates within the template grid
- Creating a new template
- Editing an existing template

We'll be moving to a different DTS backend server, so for now saving is out of scope.  With the new server, we plan to:
- Backup the database
- Have tests which edits templates and save, create templates and save
- Verify results
- Restore database to original state prior to the test
