### PR TITLE
Use new dts endpoint CEMS-2329

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -10,7 +10,7 @@
 <body>
   <app-dts
     userName = "Test User"
-    dtsUrl = "http://dts-qa.us-west-2.elasticbeanstalk.com">
+    dtsUrl = "http://dts-qa.us-west-2.elasticbeanstalk.com/api/v1">
   </app-dts>
 </body>
 </html>

--- a/src/test/document_template.php
+++ b/src/test/document_template.php
@@ -13,7 +13,7 @@
  *
  */
 
-  $dtsUrl = "http://dts-qa.us-west-2.elasticbeanstalk.com";
+  $dtsUrl = "http://dts-qa.us-west-2.elasticbeanstalk.com/api/v1";
   class User
   {
     var $userName;


### PR DESCRIPTION
Updates the new dts endpoints.  This change is primarily for testing, as in production the endpoint will come from an environment variable.  The endpoint for production will be updated in CEMS-2331.

Old
$dtsUrl = "http://dts-qa.us-west-2.elasticbeanstalk.com";

New
$dtsUrl = "http://dts-qa.us-west-2.elasticbeanstalk.com/api/v1";